### PR TITLE
Refactor button toggle handling into dedicated components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,14 @@ import { useState } from 'react';
 import { FaRegThumbsUp, FaThumbsUp } from 'react-icons/fa';
 
 import Button from '@/components/button';
-import IconButton from '@/components/button/iconButton/index.ts';
-import LoginButton from '@/components/button/loginButton/index.ts';
-import RoundButton from '@/components/button/roundButton/index.ts';
-import RoundedRectangleButton from '@/components/button/roundedRectangleButton/index.ts';
-import TextButton from '@/components/button/textButton/index.ts';
-import InputTextWithEmail from '@/components/inputTextWithEmail/index.ts';
+import IconButton, { ToggleIconButton } from '@/components/button/iconButton';
+import LoginButton from '@/components/button/loginButton';
+import RoundButton, {
+  ToggleRoundButton,
+} from '@/components/button/roundButton';
+import RoundedRectangleButton from '@/components/button/roundedRectangleButton';
+import TextButton, { ToggleTextButton } from '@/components/button/textButton';
+import InputTextWithEmail from '@/components/InputTextWithEmail';
 import MatchCard from '@/components/matchCard';
 import NavigationTab from '@/components/navigationTab';
 import HomeTitleBar from '@/components/titleBar/homeTitleBar/index.ts';
@@ -59,13 +61,13 @@ function App() {
         <S.EmailText>입력한 이메일: {email}</S.EmailText>
         <Button onClick={() => setCount((c) => c + 1)}>카운트 증가</Button>
         <S.CountText>현재 카운트: {count}</S.CountText>
-        <IconButton
+        <ToggleIconButton
           ariaLabel="좋아요 토글"
           pressed={liked}
           onPressedChange={setLiked}
         >
           {liked ? <FaThumbsUp /> : <FaRegThumbsUp />}
-        </IconButton>
+        </ToggleIconButton>
         <IconButton
           ariaLabel="아이콘 로딩"
           loading={iconLoading}
@@ -91,13 +93,13 @@ function App() {
           텍스트 증가
         </TextButton>
         <S.CountText>텍스트 카운트: {textCount}</S.CountText>
-        <TextButton
+        <ToggleTextButton
           ariaLabel="텍스트 좋아요"
           pressed={textLiked}
           onPressedChange={setTextLiked}
         >
           {textLiked ? 'ON' : 'OFF'}
-        </TextButton>
+        </ToggleTextButton>
         <TextButton
           ariaLabel="텍스트 로딩 버튼"
           loading={textLoading}
@@ -109,13 +111,13 @@ function App() {
           로딩
         </TextButton>
         <TextButton disabled>비활성 텍스트</TextButton>
-        <RoundButton
+        <ToggleRoundButton
           ariaLabel="라운드 좋아요"
           pressed={roundLiked}
           onPressedChange={setRoundLiked}
         >
           {roundLiked ? <FaThumbsUp /> : <FaRegThumbsUp />}
-        </RoundButton>
+        </ToggleRoundButton>
         <RoundButton size="lg" onClick={() => setRoundCount((c) => c + 1)}>
           GO
         </RoundButton>

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -12,8 +12,6 @@ export interface ButtonOwnProps {
   loading?: boolean;
   disabled?: boolean;
   ariaLabel?: string; // icon 변형이면 필수
-  pressed?: boolean; // 토글 상태
-  onPressedChange?: (v: boolean) => void; // 토글 핸들러(선택)
   onClick?: MouseEventHandler<HTMLButtonElement>;
   children?: ReactNode;
 }
@@ -27,8 +25,6 @@ const Button = ({
   disabled = false,
   loading = false,
   ariaLabel,
-  pressed,
-  onPressedChange,
   onClick,
   children,
   ...rest
@@ -41,13 +37,6 @@ const Button = ({
 
   const isDisabled = disabled || loading;
 
-  const handleClick: MouseEventHandler<HTMLButtonElement> = (e) => {
-    onClick?.(e);
-    if (!isDisabled && typeof pressed === 'boolean' && onPressedChange) {
-      onPressedChange(!pressed);
-    }
-  };
-
   return (
     <S.StyledButton
       type="button"
@@ -56,10 +45,9 @@ const Button = ({
       disabled={isDisabled}
       aria-label={ariaLabel}
       aria-busy={loading || undefined}
-      aria-pressed={typeof pressed === 'boolean' ? pressed : undefined}
       data-loading={loading ? 'true' : undefined}
-      onClick={handleClick}
-      {...rest}
+      onClick={onClick}
+      {...rest} /* eslint-disable-line react/jsx-props-no-spreading */
     >
       {loading ? (
         <S.Spinner role="status" aria-live="polite" aria-label="loading" />

--- a/src/components/button/iconButton/iconButton.styled.ts
+++ b/src/components/button/iconButton/iconButton.styled.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import Button from '@/components/button';
+import Button, { ToggleButton } from '@/components/button';
 import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
 import { typography } from '@/theme/typography';
@@ -27,3 +27,6 @@ export const StyledIconButton = styled(Button)`
     height: ${spacing.spacing5};
   }
 `;
+
+export const StyledToggleIconButton =
+  StyledIconButton.withComponent(ToggleButton);

--- a/src/components/button/iconButton/iconButton.tsx
+++ b/src/components/button/iconButton/iconButton.tsx
@@ -12,7 +12,11 @@ export interface IconButtonProps
 
 const IconButton = ({ ariaLabel, children, ...rest }: IconButtonProps) => {
   return (
-    <S.StyledIconButton variant="icon" ariaLabel={ariaLabel} {...rest}>
+    <S.StyledIconButton
+      variant="icon"
+      ariaLabel={ariaLabel}
+      {...rest} /* eslint-disable-line react/jsx-props-no-spreading */
+    >
       {children}
     </S.StyledIconButton>
   );

--- a/src/components/button/iconButton/index.ts
+++ b/src/components/button/iconButton/index.ts
@@ -1,2 +1,4 @@
 export { default } from './iconButton';
 export * from './iconButton';
+export { default as ToggleIconButton } from './toggleIconButton';
+export * from './toggleIconButton';

--- a/src/components/button/iconButton/toggleIconButton.tsx
+++ b/src/components/button/iconButton/toggleIconButton.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+
+import type { ToggleButtonProps } from '@/components/button/toggleButton';
+
+import * as S from './iconButton.styled';
+
+export interface ToggleIconButtonProps
+  extends Omit<ToggleButtonProps, 'variant' | 'ariaLabel'> {
+  ariaLabel: string;
+  children?: ReactNode;
+}
+
+const ToggleIconButton = ({
+  ariaLabel,
+  children,
+  ...rest
+}: ToggleIconButtonProps) => {
+  return (
+    <S.StyledToggleIconButton
+      variant="icon"
+      ariaLabel={ariaLabel}
+      {...rest} /* eslint-disable-line react/jsx-props-no-spreading */
+    >
+      {children}
+    </S.StyledToggleIconButton>
+  );
+};
+
+export default ToggleIconButton;

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -1,2 +1,4 @@
 export { default } from './button';
 export * from './button';
+export { default as ToggleButton } from './toggleButton';
+export * from './toggleButton';

--- a/src/components/button/loginButton/index.ts
+++ b/src/components/button/loginButton/index.ts
@@ -1,2 +1,4 @@
 export { default } from './loginButton.tsx';
 export type { LoginButtonProps } from './loginButton.tsx';
+export { default as ToggleLoginButton } from './toggleLoginButton';
+export type { ToggleLoginButtonProps } from './toggleLoginButton';

--- a/src/components/button/loginButton/loginButton.styled.ts
+++ b/src/components/button/loginButton/loginButton.styled.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import Button from '@/components/button';
+import Button, { ToggleButton } from '@/components/button';
 import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
 import { typography } from '@/theme/typography';
@@ -20,3 +20,6 @@ export const StyledLoginButton = styled(Button)`
     background: ${colors.brand.kakaoYellowPressed};
   }
 `;
+
+export const StyledToggleLoginButton =
+  StyledLoginButton.withComponent(ToggleButton);

--- a/src/components/button/loginButton/loginButton.tsx
+++ b/src/components/button/loginButton/loginButton.tsx
@@ -14,7 +14,10 @@ const LoginButton = ({
   ...rest
 }: LoginButtonProps) => {
   return (
-    <S.StyledLoginButton variant="login" {...rest}>
+    <S.StyledLoginButton
+      variant="login"
+      {...rest} /* eslint-disable-line react/jsx-props-no-spreading */
+    >
       {children}
     </S.StyledLoginButton>
   );

--- a/src/components/button/loginButton/toggleLoginButton.tsx
+++ b/src/components/button/loginButton/toggleLoginButton.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+
+import type { ToggleButtonProps } from '@/components/button/toggleButton';
+
+import * as S from './loginButton.styled';
+
+export interface ToggleLoginButtonProps
+  extends Omit<ToggleButtonProps, 'variant' | 'children'> {
+  children?: ReactNode;
+}
+
+const ToggleLoginButton = ({
+  children = '카카오로 시작하기',
+  ...rest
+}: ToggleLoginButtonProps) => {
+  return (
+    <S.StyledToggleLoginButton
+      variant="login"
+      {...rest} /* eslint-disable-line react/jsx-props-no-spreading */
+    >
+      {children}
+    </S.StyledToggleLoginButton>
+  );
+};
+
+export default ToggleLoginButton;

--- a/src/components/button/roundButton/index.ts
+++ b/src/components/button/roundButton/index.ts
@@ -1,2 +1,4 @@
 export { default } from './roundButton';
 export type { RoundButtonProps } from './roundButton';
+export { default as ToggleRoundButton } from './toggleRoundButton';
+export type { ToggleRoundButtonProps } from './toggleRoundButton';

--- a/src/components/button/roundButton/roundButton.styled.ts
+++ b/src/components/button/roundButton/roundButton.styled.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-import Button from '@/components/button';
+import Button, { ToggleButton } from '@/components/button';
 import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
 import { typography } from '@/theme/typography';
@@ -43,3 +43,6 @@ export const StyledRoundButton = styled(Button)<{ size: 'md' | 'lg' }>`
     background: ${colors.brand.kakaoYellowPressed};
   }
 `;
+
+export const StyledToggleRoundButton =
+  StyledRoundButton.withComponent(ToggleButton);

--- a/src/components/button/roundButton/roundButton.tsx
+++ b/src/components/button/roundButton/roundButton.tsx
@@ -12,7 +12,11 @@ export interface RoundButtonProps
 
 const RoundButton = ({ size = 'md', children, ...rest }: RoundButtonProps) => {
   return (
-    <S.StyledRoundButton variant="round" size={size} {...rest}>
+    <S.StyledRoundButton
+      variant="round"
+      size={size}
+      {...rest} /* eslint-disable-line react/jsx-props-no-spreading */
+    >
       {children}
     </S.StyledRoundButton>
   );

--- a/src/components/button/roundButton/toggleRoundButton.tsx
+++ b/src/components/button/roundButton/toggleRoundButton.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+
+import type { ToggleButtonProps } from '@/components/button/toggleButton';
+
+import * as S from './roundButton.styled';
+
+export interface ToggleRoundButtonProps
+  extends Omit<ToggleButtonProps, 'variant' | 'size'> {
+  size?: 'md' | 'lg';
+  children?: ReactNode;
+}
+
+const ToggleRoundButton = ({
+  size = 'md',
+  children,
+  ...rest
+}: ToggleRoundButtonProps) => {
+  return (
+    <S.StyledToggleRoundButton
+      variant="round"
+      size={size}
+      {...rest} /* eslint-disable-line react/jsx-props-no-spreading */
+    >
+      {children}
+    </S.StyledToggleRoundButton>
+  );
+};
+
+export default ToggleRoundButton;

--- a/src/components/button/roundedRectangleButton/index.ts
+++ b/src/components/button/roundedRectangleButton/index.ts
@@ -1,2 +1,4 @@
 export { default } from './roundedRectangleButton';
 export * from './roundedRectangleButton';
+export { default as ToggleRoundedRectangleButton } from './toggleRoundedRectangleButton';
+export * from './toggleRoundedRectangleButton';

--- a/src/components/button/roundedRectangleButton/roundedRectangleButton.styled.ts
+++ b/src/components/button/roundedRectangleButton/roundedRectangleButton.styled.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-import Button from '@/components/button';
+import Button, { ToggleButton } from '@/components/button';
 import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
 
@@ -40,3 +40,6 @@ export const StyledRoundedRectangleButton = styled(Button, {
     `;
   }}
 `;
+
+export const StyledToggleRoundedRectangleButton =
+  StyledRoundedRectangleButton.withComponent(ToggleButton);

--- a/src/components/button/roundedRectangleButton/roundedRectangleButton.tsx
+++ b/src/components/button/roundedRectangleButton/roundedRectangleButton.tsx
@@ -19,7 +19,7 @@ const RoundedRectangleButton = ({
     <S.StyledRoundedRectangleButton
       variant="secondary"
       colorSet={colorSet}
-      {...rest}
+      {...rest} /* eslint-disable-line react/jsx-props-no-spreading */
     >
       {children}
     </S.StyledRoundedRectangleButton>

--- a/src/components/button/roundedRectangleButton/toggleRoundedRectangleButton.tsx
+++ b/src/components/button/roundedRectangleButton/toggleRoundedRectangleButton.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+
+import type { ToggleButtonProps } from '@/components/button/toggleButton';
+
+import * as S from './roundedRectangleButton.styled';
+
+export interface ToggleRoundedRectangleButtonProps
+  extends Omit<ToggleButtonProps, 'variant'> {
+  colorSet?: S.RoundedRectangleColors;
+  children?: ReactNode;
+}
+
+const ToggleRoundedRectangleButton = ({
+  colorSet,
+  children,
+  ...rest
+}: ToggleRoundedRectangleButtonProps) => {
+  return (
+    <S.StyledToggleRoundedRectangleButton
+      variant="secondary"
+      colorSet={colorSet}
+      {...rest} /* eslint-disable-line react/jsx-props-no-spreading */
+    >
+      {children}
+    </S.StyledToggleRoundedRectangleButton>
+  );
+};
+
+export default ToggleRoundedRectangleButton;

--- a/src/components/button/textButton/index.ts
+++ b/src/components/button/textButton/index.ts
@@ -1,2 +1,4 @@
 export { default } from './textButton';
 export * from './textButton';
+export { default as ToggleTextButton } from './toggleTextButton';
+export * from './toggleTextButton';

--- a/src/components/button/textButton/textButton.styled.ts
+++ b/src/components/button/textButton/textButton.styled.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import Button from '@/components/button';
+import Button, { ToggleButton } from '@/components/button';
 import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
 import { typography } from '@/theme/typography';
@@ -20,3 +20,6 @@ export const StyledTextButton = styled(Button)`
     background: ${colors.gray[200]};
   }
 `;
+
+export const StyledToggleTextButton =
+  StyledTextButton.withComponent(ToggleButton);

--- a/src/components/button/textButton/textButton.tsx
+++ b/src/components/button/textButton/textButton.tsx
@@ -10,7 +10,10 @@ export interface TextButtonProps extends Omit<ButtonProps, 'variant'> {
 
 const TextButton = ({ children, ...rest }: TextButtonProps) => {
   return (
-    <S.StyledTextButton variant="text" {...rest}>
+    <S.StyledTextButton
+      variant="text"
+      {...rest} /* eslint-disable-line react/jsx-props-no-spreading */
+    >
       {children}
     </S.StyledTextButton>
   );

--- a/src/components/button/textButton/toggleTextButton.tsx
+++ b/src/components/button/textButton/toggleTextButton.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+import type { ToggleButtonProps } from '@/components/button/toggleButton';
+
+import * as S from './textButton.styled';
+
+export interface ToggleTextButtonProps
+  extends Omit<ToggleButtonProps, 'variant'> {
+  children?: ReactNode;
+}
+
+const ToggleTextButton = ({ children, ...rest }: ToggleTextButtonProps) => {
+  return (
+    <S.StyledToggleTextButton
+      variant="text"
+      {...rest} /* eslint-disable-line react/jsx-props-no-spreading */
+    >
+      {children}
+    </S.StyledToggleTextButton>
+  );
+};
+
+export default ToggleTextButton;

--- a/src/components/button/toggleButton/index.ts
+++ b/src/components/button/toggleButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from './toggleButton';
+export * from './toggleButton';

--- a/src/components/button/toggleButton/toggleButton.tsx
+++ b/src/components/button/toggleButton/toggleButton.tsx
@@ -1,0 +1,39 @@
+import type { MouseEventHandler } from 'react';
+
+import Button from '@/components/button/button';
+import type { ButtonProps } from '@/components/button/button';
+
+export interface ToggleButtonProps extends ButtonProps {
+  pressed: boolean;
+  onPressedChange: (pressed: boolean) => void;
+}
+
+const ToggleButton = ({
+  pressed,
+  onPressedChange,
+  onClick,
+  disabled = false,
+  loading = false,
+  ...rest
+}: ToggleButtonProps) => {
+  const isDisabled = disabled || loading;
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+    onClick?.(event);
+    if (!isDisabled) {
+      onPressedChange(!pressed);
+    }
+  };
+
+  return (
+    <Button
+      {...rest} /* eslint-disable-line react/jsx-props-no-spreading */
+      disabled={disabled}
+      loading={loading}
+      aria-pressed={pressed}
+      onClick={handleClick}
+    />
+  );
+};
+
+export default ToggleButton;

--- a/src/tests/component/button/button.test.tsx
+++ b/src/tests/component/button/button.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 
-import Button from '@/components/button';
+import Button, { ToggleButton } from '@/components/button';
 import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
 
@@ -35,22 +35,6 @@ describe('Button', () => {
     );
   });
 
-  it('toggles pressed state', () => {
-    const handleChange = vi.fn();
-    render(
-      <Button
-        variant="icon"
-        ariaLabel="좋아요"
-        pressed={false}
-        onPressedChange={handleChange}
-      >
-        🤍
-      </Button>,
-    );
-    fireEvent.click(screen.getByRole('button', { name: '좋아요' }));
-    expect(handleChange).toHaveBeenCalledWith(true);
-  });
-
   it('shows spinner and sets aria-busy when loading', () => {
     render(<Button loading ariaLabel="로딩 버튼" />);
     const btn = screen.getByRole('button', { name: '로딩 버튼' });
@@ -70,5 +54,23 @@ describe('Button', () => {
     expect(screen.getByRole('button', { name: '큰 버튼' })).toHaveStyle(
       `padding: ${spacing.spacing4} ${spacing.spacing6}`,
     );
+  });
+});
+
+describe('ToggleButton', () => {
+  it('toggles pressed state', () => {
+    const handleChange = vi.fn();
+    render(
+      <ToggleButton
+        variant="icon"
+        ariaLabel="좋아요"
+        pressed={false}
+        onPressedChange={handleChange}
+      >
+        🤍
+      </ToggleButton>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '좋아요' }));
+    expect(handleChange).toHaveBeenCalledWith(true);
   });
 });

--- a/src/tests/component/button/iconButton.test.tsx
+++ b/src/tests/component/button/iconButton.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { FaThumbsUp } from 'react-icons/fa';
 import { describe, it, expect, vi } from 'vitest';
 
-import IconButton from '@/components/button/iconButton';
+import IconButton, { ToggleIconButton } from '@/components/button/iconButton';
 import { spacing } from '@/theme/spacing';
 
 describe('IconButton', () => {
@@ -18,13 +18,13 @@ describe('IconButton', () => {
   it('handles pressed state change', () => {
     const handleChange = vi.fn();
     render(
-      <IconButton
+      <ToggleIconButton
         ariaLabel="toggle"
         pressed={false}
         onPressedChange={handleChange}
       >
         <FaThumbsUp />
-      </IconButton>,
+      </ToggleIconButton>,
     );
     fireEvent.click(screen.getByRole('button', { name: 'toggle' }));
     expect(handleChange).toHaveBeenCalledWith(true);

--- a/src/tests/component/button/loginButton.test.tsx
+++ b/src/tests/component/button/loginButton.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 
-import LoginButton from '@/components/button/loginButton';
+import LoginButton, {
+  ToggleLoginButton,
+} from '@/components/button/loginButton';
 import { colors } from '@/theme/color';
 
 describe('LoginButton', () => {
@@ -43,7 +45,7 @@ describe('LoginButton', () => {
   it('toggles pressed state', () => {
     const handleChange = vi.fn();
     render(
-      <LoginButton
+      <ToggleLoginButton
         ariaLabel="로그인 토글"
         pressed={false}
         onPressedChange={handleChange}

--- a/src/tests/component/button/roundButton.test.tsx
+++ b/src/tests/component/button/roundButton.test.tsx
@@ -2,7 +2,9 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { FaThumbsUp } from 'react-icons/fa';
 import { describe, it, expect, vi } from 'vitest';
 
-import RoundButton from '@/components/button/roundButton';
+import RoundButton, {
+  ToggleRoundButton,
+} from '@/components/button/roundButton';
 import { spacing } from '@/theme/spacing';
 
 describe('RoundButton', () => {
@@ -18,13 +20,13 @@ describe('RoundButton', () => {
   it('handles pressed state change', () => {
     const handleChange = vi.fn();
     render(
-      <RoundButton
+      <ToggleRoundButton
         ariaLabel="toggle"
         pressed={false}
         onPressedChange={handleChange}
       >
         <FaThumbsUp />
-      </RoundButton>,
+      </ToggleRoundButton>,
     );
     fireEvent.click(screen.getByRole('button', { name: 'toggle' }));
     expect(handleChange).toHaveBeenCalledWith(true);

--- a/src/tests/component/button/roundedRectangleButton.test.tsx
+++ b/src/tests/component/button/roundedRectangleButton.test.tsx
@@ -1,7 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import RoundedRectangleButton from '@/components/button/roundedRectangleButton';
+import RoundedRectangleButton, {
+  ToggleRoundedRectangleButton,
+} from '@/components/button/roundedRectangleButton';
 import { colors } from '@/theme/color';
 
 describe('RoundedRectangleButton', () => {
@@ -58,7 +60,7 @@ describe('RoundedRectangleButton', () => {
   it('toggles pressed state', () => {
     const handle = vi.fn();
     render(
-      <RoundedRectangleButton
+      <ToggleRoundedRectangleButton
         ariaLabel="토글"
         pressed={false}
         onPressedChange={handle}

--- a/src/tests/component/button/textButton.test.tsx
+++ b/src/tests/component/button/textButton.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import TextButton from '@/components/button/textButton';
+import TextButton, { ToggleTextButton } from '@/components/button/textButton';
 import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
 
@@ -40,7 +40,11 @@ describe('TextButton', () => {
   it('toggles pressed state', () => {
     const handle = vi.fn();
     render(
-      <TextButton ariaLabel="토글" pressed={false} onPressedChange={handle} />,
+      <ToggleTextButton
+        ariaLabel="토글"
+        pressed={false}
+        onPressedChange={handle}
+      />,
     );
     fireEvent.click(screen.getByRole('button', { name: '토글' }));
     expect(handle).toHaveBeenCalledWith(true);

--- a/src/tests/component/others/inputTextWithEmail.test.tsx
+++ b/src/tests/component/others/inputTextWithEmail.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 
-import InputTextWithEmail from '@/components/inputTextWithEmail';
+import InputTextWithEmail from '@/components/InputTextWithEmail';
 
 describe('InputTextWithEmail', () => {
   it('renders default domain', () => {


### PR DESCRIPTION
## Summary
- 분기 로직을 제거하고 기본 Button 컴포넌트를 단순화했습니다.
- 토글 동작을 위한 ToggleButton과 각 버튼 변형의 토글 전용 컴포넌트를 추가했습니다.
- App과 관련 테스트를 새로운 토글 컴포넌트를 사용하도록 업데이트했습니다.

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68ce31630ba883328666785c67f41c1a