### PR TITLE
feat: apply refreshed onboarding and profile styling

### DIFF
--- a/src/components/layout/PageActions.styled.ts
+++ b/src/components/layout/PageActions.styled.ts
@@ -1,38 +1,140 @@
+import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 
-export const Bar = styled.div`
+const shimmer = keyframes`
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+`;
+
+const slideUp = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+export const Container = styled.div`
   position: sticky;
   bottom: 0;
-  z-index: 10;
+  left: 0;
+  right: 0;
   display: flex;
-  justify-content: space-between;
-  gap: ${({ theme }) => theme.spacing2};
-  padding: ${({ theme }) => `${theme.spacing3} ${theme.spacing4}`};
-  background-color: ${({ theme }) => theme.background.fill};
-  border-top: 1px solid ${({ theme }) => theme.border.default};
+  gap: 16px;
+  padding: 20px 16px;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(20px);
+  border-top: 1px solid rgba(226, 232, 240, 0.8);
+  box-shadow: 0 -4px 24px rgba(15, 23, 42, 0.08);
+  animation: ${slideUp} 0.4s ease-out;
+  z-index: 100;
+
+  @media (min-width: 640px) {
+    padding: 24px 32px;
+  }
 `;
 
-export const Secondary = styled.button`
-  padding: ${({ theme }) => `${theme.spacing2} ${theme.spacing4}`};
-  border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.border.default};
-  background: ${({ theme }) => theme.gray[100]};
-  color: ${({ theme }) => theme.text.default};
+export const ResetButton = styled.button`
+  padding: 14px 24px;
+  border-radius: 14px;
+  border: 2px solid #e2e8f0;
+  background: white;
+  color: #64748b;
+  font-size: 15px;
+  font-weight: 600;
   cursor: pointer;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  white-space: nowrap;
+
+  &:hover {
+    border-color: #cbd5e1;
+    background: #f8fafc;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.1);
+  }
+
+  &:active {
+    transform: translateY(0);
+    box-shadow: 0 2px 6px rgba(15, 23, 42, 0.1);
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgba(100, 116, 139, 0.3);
+    outline-offset: 2px;
+  }
 `;
 
-export const Primary = styled.button`
-  padding: ${({ theme }) => `${theme.spacing2} ${theme.spacing4}`};
-  border-radius: 12px;
-  border: 0;
-  background: ${({ theme }) => theme.blue[700]};
-  color: ${({ theme }) => theme.gray[0]};
-  font-weight: ${({ theme }) => theme.body1Bold.fontWeight};
-  cursor: pointer;
-  transition: opacity 0.2s ease;
+export const NextButton = styled.button<{ disabled?: boolean }>`
+  flex: 1;
+  padding: 14px 32px;
+  border-radius: 14px;
+  border: none;
+  background: ${({ disabled }) =>
+    disabled ? '#E2E8F0' : 'linear-gradient(135deg, #3B82F6 0%, #2563EB 100%)'};
+  color: ${({ disabled }) => (disabled ? '#94A3B8' : 'white')};
+  font-size: 16px;
+  font-weight: 700;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+  box-shadow: ${({ disabled }) =>
+    disabled
+      ? 'none'
+      : '0 4px 16px rgba(59, 130, 246, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.2)'};
 
-  &:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
+  ${({ disabled }) =>
+    !disabled &&
+    css`
+      &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: linear-gradient(
+          90deg,
+          transparent,
+          rgba(255, 255, 255, 0.3),
+          transparent
+        );
+        background-size: 200% 100%;
+        animation: ${shimmer} 2s ease-in-out infinite;
+      }
+    `}
+
+  &:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(59, 130, 246, 0.4);
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow: 0 2px 12px rgba(37, 99, 235, 0.4);
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgba(59, 130, 246, 0.4);
+    outline-offset: 2px;
+  }
+
+  &::after {
+    content: '→';
+    margin-left: 8px;
+    font-size: 18px;
+    transition: transform 0.3s ease;
+    display: inline-block;
+  }
+
+  &:hover:not(:disabled)::after {
+    transform: translateX(4px);
   }
 `;

--- a/src/components/layout/PageActions.tsx
+++ b/src/components/layout/PageActions.tsx
@@ -4,22 +4,35 @@ type Props = {
   onReset?: () => void;
   onNext?: () => void;
   nextDisabled?: boolean;
+  nextLabel?: string;
+  resetLabel?: string;
 };
 
-export default function PageActions({ onReset, onNext, nextDisabled }: Props) {
+export default function PageActions({
+  onReset,
+  onNext,
+  nextDisabled = false,
+  nextLabel = '다음',
+  resetLabel = '초기화',
+}: Props) {
+  const nextDescription = nextDisabled
+    ? '최소 1개 이상 선택해주세요'
+    : '다음 단계로';
+
   return (
-    <S.Bar>
-      <S.Secondary type="button" onClick={onReset} aria-label="reset">
-        초기화
-      </S.Secondary>
-      <S.Primary
+    <S.Container>
+      <S.ResetButton type="button" onClick={onReset} aria-label="선택 초기화">
+        {resetLabel}
+      </S.ResetButton>
+      <S.NextButton
         type="button"
         onClick={onNext}
         disabled={nextDisabled}
         aria-label="next"
+        aria-description={nextDescription}
       >
-        다음
-      </S.Primary>
-    </S.Bar>
+        {nextLabel}
+      </S.NextButton>
+    </S.Container>
   );
 }

--- a/src/components/selection/SelectCard.styled.ts
+++ b/src/components/selection/SelectCard.styled.ts
@@ -1,59 +1,259 @@
+import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 
-export const Card = styled.button<{ selected?: boolean }>`
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: ${({ theme }) => theme.spacing2};
-  width: 100%;
-  padding: ${({ theme }) => `${theme.spacing3} ${theme.spacing3}`};
-  border-radius: 14px;
-  border: 1px solid
-    ${({ theme, selected }) =>
-      selected ? theme.blue[600] : theme.border.disabled};
-  background: ${({ theme }) => theme.gray[100]};
-  text-align: left;
+const scaleIn = keyframes`
+  from {
+    opacity: 0;
+    transform: scale(0.92) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+`;
+
+export const pulse = keyframes`
+  0%, 100% {
+    box-shadow: 
+      0 8px 24px rgba(59, 130, 246, 0.15), 
+      0 0 0 0 rgba(59, 130, 246, 0.4),
+      inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  }
+  50% {
+    box-shadow: 
+      0 12px 32px rgba(59, 130, 246, 0.25),
+      0 0 0 6px rgba(59, 130, 246, 0),
+      inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  }
+`;
+
+const shimmer = keyframes`
+  0% {
+    transform: translateX(-100%) rotate(45deg);
+  }
+  100% {
+    transform: translateX(300%) rotate(45deg);
+  }
+`;
+
+const bounce = keyframes`
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.1); }
+`;
+
+export const Card = styled.button<{ selected: boolean }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  padding: 28px 22px;
+  border-radius: 24px;
+  border: 2px solid
+    ${({ selected }) => (selected ? '#3B82F6' : 'rgba(226, 232, 240, 0.8)')};
+  background: ${({ selected }) =>
+    selected
+      ? 'linear-gradient(135deg, rgba(59, 130, 246, 0.12) 0%, rgba(147, 197, 253, 0.12) 100%)'
+      : 'linear-gradient(135deg, #FFFFFF 0%, #F8FAFC 100%)'};
   cursor: pointer;
-  transition:
-    box-shadow 0.2s ease,
-    border-color 0.2s ease,
-    transform 0.2s ease;
+  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+  animation: ${scaleIn} 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
+  box-shadow: ${({ selected }) =>
+    selected
+      ? '0 8px 24px rgba(59, 130, 246, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.5), 0 1px 3px rgba(15, 23, 42, 0.1)'
+      : '0 2px 8px rgba(15, 23, 42, 0.06), 0 1px 3px rgba(15, 23, 42, 0.04)'};
+  --icon-transform: scale(1) rotate(0deg);
+  --icon-filter: ${({ selected }) =>
+    selected
+      ? 'drop-shadow(0 4px 12px rgba(59, 130, 246, 0.4))'
+      : 'drop-shadow(0 2px 4px rgba(15, 23, 42, 0.1))'};
+  --title-color: ${({ selected }) => (selected ? '#1E40AF' : '#0F172A')};
+  --caption-color: ${({ selected }) => (selected ? '#3B82F6' : '#64748B')};
+  --caption-opacity: ${({ selected }) => (selected ? 1 : 0.85)};
+
+  /* 상단 그라디언트 바 */
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #3b82f6 0%, #8b5cf6 50%, #ec4899 100%);
+    opacity: ${({ selected }) => (selected ? 1 : 0)};
+    transition: opacity 0.35s ease;
+  }
+
+  /* 선택 시 배경 shimmer 효과 */
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 50%;
+    height: 100%;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      rgba(255, 255, 255, 0.3) 50%,
+      transparent 100%
+    );
+    opacity: ${({ selected }) => (selected ? 1 : 0)};
+    animation: ${({ selected }) => (selected ? shimmer : 'none')} 3s ease-in-out
+      infinite;
+  }
 
   &:hover {
-    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
-    transform: translateY(-1px);
+    transform: translateY(-6px) scale(1.03);
+    border-color: ${({ selected }) => (selected ? '#2563EB' : '#BFDBFE')};
+    box-shadow: ${({ selected }) =>
+      selected
+        ? '0 16px 40px rgba(59, 130, 246, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.6)'
+        : '0 12px 28px rgba(15, 23, 42, 0.14), 0 4px 12px rgba(15, 23, 42, 0.08)'};
+    background: ${({ selected }) =>
+      selected
+        ? 'linear-gradient(135deg, rgba(59, 130, 246, 0.16) 0%, rgba(147, 197, 253, 0.16) 100%)'
+        : 'linear-gradient(135deg, #FFFFFF 0%, #EFF6FF 100%)'};
+    --icon-transform: scale(1.2) rotate(8deg);
+    --icon-filter: ${({ selected }) =>
+      selected
+        ? 'drop-shadow(0 8px 16px rgba(59, 130, 246, 0.5))'
+        : 'drop-shadow(0 4px 8px rgba(15, 23, 42, 0.15))'};
+    --title-color: ${({ selected }) => (selected ? '#1E3A8A' : '#1E293B')};
+    --caption-color: ${({ selected }) => (selected ? '#2563EB' : '#475569')};
+    --caption-opacity: 1;
   }
+
   &:active {
-    transform: translateY(0);
+    transform: translateY(-3px) scale(0.98);
+    transition: all 0.1s ease;
+    --icon-transform: scale(1.1) rotate(4deg);
   }
+
+  ${({ selected }) =>
+    selected &&
+    css`
+      animation:
+        ${scaleIn} 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) backwards,
+        ${pulse} 3s ease-in-out 0.5s infinite;
+    `}
+
   &:focus-visible {
-    outline: 3px solid rgba(33, 124, 249, 0.35);
-    outline-offset: 2px;
+    outline: 3px solid rgba(59, 130, 246, 0.5);
+    outline-offset: 3px;
   }
 `;
 
-export const Icon = styled.span`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+export const IconWrapper = styled.div<{ selected: boolean }>`
+  font-size: 48px;
+  line-height: 1;
+  transition: all 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transform: var(--icon-transform, scale(1) rotate(0deg));
+  filter: var(
+    --icon-filter,
+    ${({ selected }) =>
+      selected
+        ? 'drop-shadow(0 4px 12px rgba(59, 130, 246, 0.4))'
+        : 'drop-shadow(0 2px 4px rgba(15, 23, 42, 0.1))'}
+  );
+  position: relative;
+  z-index: 1;
+`;
+
+export const Title = styled.h3<{ selected: boolean }>`
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(
+    --title-color,
+    ${({ selected }) => (selected ? '#1E40AF' : '#0F172A')}
+  );
+  letter-spacing: -0.02em;
+  transition: all 0.3s ease;
+  position: relative;
+  z-index: 1;
+`;
+
+export const Caption = styled.p<{ selected: boolean }>`
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(
+    --caption-color,
+    ${({ selected }) => (selected ? '#3B82F6' : '#64748B')}
+  );
+  transition: all 0.3s ease;
+  text-align: center;
+  line-height: 1.5;
+  position: relative;
+  z-index: 1;
+  opacity: var(--caption-opacity, ${({ selected }) => (selected ? 1 : 0.85)});
+`;
+
+export const CheckIcon = styled.div<{ visible: boolean }>`
+  position: absolute;
+  top: 14px;
+  right: 14px;
   width: 28px;
   height: 28px;
-  font-size: 18px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: ${({ visible }) => (visible ? 1 : 0)};
+  transform: ${({ visible }) =>
+    visible ? 'scale(1) rotate(0deg)' : 'scale(0.3) rotate(-180deg)'};
+  transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+  box-shadow: ${({ visible }) =>
+    visible ? '0 4px 16px rgba(59, 130, 246, 0.5)' : 'none'};
+  z-index: 2;
+  animation: ${({ visible }) => (visible ? bounce : 'none')} 0.6s ease-in-out
+    0.2s;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: -4px;
+    border-radius: 50%;
+    background: linear-gradient(
+      135deg,
+      rgba(59, 130, 246, 0.3),
+      rgba(37, 99, 235, 0.3)
+    );
+    opacity: ${({ visible }) => (visible ? 1 : 0)};
+    transition: opacity 0.3s ease;
+  }
+
+  &::after {
+    content: '✓';
+    color: white;
+    font-size: 16px;
+    font-weight: 900;
+    position: relative;
+    z-index: 1;
+  }
 `;
 
-export const Texts = styled.div`
-  display: grid;
-  gap: ${({ theme }) => theme.spacing1};
-`;
-
-export const Title = styled.strong`
-  color: ${({ theme }) => theme.text.default};
-  font-size: ${({ theme }) => theme.body1Bold.fontSize};
-  font-weight: ${({ theme }) => theme.body1Bold.fontWeight};
-  line-height: ${({ theme }) => theme.body1Bold.lineHeight};
-`;
-
-export const Caption = styled.span`
-  color: ${({ theme }) => theme.text.sub};
-  font-size: ${({ theme }) => theme.label1Regular.fontSize};
-  line-height: ${({ theme }) => theme.label1Regular.lineHeight};
+export const SelectionBadge = styled.div<{ visible: boolean }>`
+  position: absolute;
+  bottom: 14px;
+  left: 50%;
+  transform: translateX(-50%)
+    ${({ visible }) => (visible ? 'translateY(0)' : 'translateY(10px)')};
+  padding: 4px 12px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  color: white;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  opacity: ${({ visible }) => (visible ? 1 : 0)};
+  transition: all 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+  box-shadow: 0 2px 8px rgba(59, 130, 246, 0.4);
+  z-index: 2;
+  pointer-events: none;
+  white-space: nowrap;
 `;

--- a/src/components/selection/SelectCard.tsx
+++ b/src/components/selection/SelectCard.tsx
@@ -17,18 +17,21 @@ export default function SelectCard({
   selected,
   onToggle,
 }: Props) {
+  const isSelected = Boolean(selected);
+
   return (
     <S.Card
       type="button"
-      aria-pressed={Boolean(selected)}
-      selected={selected}
+      selected={isSelected}
+      aria-pressed={isSelected}
+      aria-label={`${title} ${isSelected ? '선택됨' : '선택 안됨'}`}
       onClick={onToggle}
     >
-      {icon && <S.Icon aria-hidden>{icon}</S.Icon>}
-      <S.Texts>
-        <S.Title>{title}</S.Title>
-        {caption && <S.Caption>{caption}</S.Caption>}
-      </S.Texts>
+      <S.CheckIcon visible={isSelected} aria-hidden="true" />
+      {icon && <S.IconWrapper selected={isSelected}>{icon}</S.IconWrapper>}
+      <S.Title selected={isSelected}>{title}</S.Title>
+      {caption && <S.Caption selected={isSelected}>{caption}</S.Caption>}
+      <S.SelectionBadge visible={isSelected}>선택됨</S.SelectionBadge>
     </S.Card>
   );
 }

--- a/src/pages/My/MyPage.styled.ts
+++ b/src/pages/My/MyPage.styled.ts
@@ -1,131 +1,317 @@
+import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 
-import { colors } from '@/theme/color';
-import { spacing } from '@/theme/spacing';
-import { typography } from '@/theme/typography';
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const float = keyframes`
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-4px);
+  }
+`;
+
+const shimmer = keyframes`
+  0% {
+    background-position: -100% 0;
+  }
+  100% {
+    background-position: 100% 0;
+  }
+`;
 
 export const Page = styled.main`
   display: flex;
   flex-direction: column;
-  gap: ${spacing.spacing5};
   min-height: 100vh;
-  padding: ${spacing.spacing6} ${spacing.spacing4};
-  background-color: ${colors.background.fill};
+  background: linear-gradient(180deg, #eff6ff 0%, #dbeafe 50%, #bfdbfe 100%);
+  position: relative;
+  animation: ${fadeIn} 0.5s ease-out;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 400px;
+    background: radial-gradient(
+      circle at 50% 0%,
+      rgba(59, 130, 246, 0.12) 0%,
+      transparent 70%
+    );
+    pointer-events: none;
+  }
 `;
 
 export const TitleBarWrapper = styled.div`
   width: 100%;
-  max-width: 560px;
+  padding: ${({ theme }) => theme.spacing4} ${({ theme }) => theme.spacing4} 0;
+  max-width: 640px;
   margin: 0 auto;
+  position: relative;
+  z-index: 10;
 `;
 
 export const ProfileSection = styled.section`
   display: flex;
   flex-direction: column;
-  gap: ${spacing.spacing4};
-  max-width: 560px;
+  gap: ${({ theme }) => theme.spacing5};
+  max-width: 640px;
   width: 100%;
-  margin: 0 auto;
-  padding: ${spacing.spacing6} ${spacing.spacing4};
-  border-radius: 24px;
-  background-color: ${colors.gray[0]};
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
+  margin: ${({ theme }) => theme.spacing6} auto;
+  padding: ${({ theme }) => theme.spacing7};
+  border-radius: 32px;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(20px);
+  box-shadow:
+    0 1px 3px rgba(15, 23, 42, 0.06),
+    0 8px 24px rgba(59, 130, 246, 0.12),
+    0 16px 48px rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.8);
+  position: relative;
+  z-index: 1;
+  animation: ${fadeIn} 0.6s ease-out 0.1s both;
+
+  @media (max-width: 640px) {
+    margin: ${({ theme }) => theme.spacing4};
+    padding: ${({ theme }) => theme.spacing6} ${({ theme }) => theme.spacing5};
+  }
 `;
 
 export const Heading = styled.h1`
-  ${typography.title1Bold};
-  color: ${colors.text.default};
+  ${({ theme }) => theme.title1Bold};
+  color: #0f172a;
   margin: 0;
+  font-size: 32px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  background: linear-gradient(135deg, #0f172a 0%, #1e40af 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+`;
+
+export const AvatarWrapper = styled.div`
+  position: relative;
+  width: 112px;
+  height: 112px;
+  margin: ${({ theme }) => theme.spacing3} 0;
+  animation: ${float} 3s ease-in-out infinite;
 `;
 
 export const Avatar = styled.img`
-  width: 96px;
-  height: 96px;
+  width: 100%;
+  height: 100%;
   border-radius: 50%;
   object-fit: cover;
-  border: 4px solid ${colors.yellow[200]};
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+  border: 5px solid white;
+  box-shadow:
+    0 8px 24px rgba(59, 130, 246, 0.2),
+    0 0 0 1px rgba(59, 130, 246, 0.1);
+  transition: transform 0.3s ease;
+
+  &:hover {
+    transform: scale(1.05);
+  }
+`;
+
+export const AvatarBadge = styled.div`
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  border: 3px solid white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
+
+  &::after {
+    content: '✓';
+    color: white;
+    font-weight: bold;
+  }
 `;
 
 export const UserMeta = styled.div`
   display: flex;
   flex-direction: column;
-  gap: ${spacing.spacing1};
+  gap: ${({ theme }) => theme.spacing1};
 `;
 
 export const UserName = styled.h2`
-  ${typography.title2Bold};
-  color: ${colors.text.default};
+  ${({ theme }) => theme.title2Bold};
+  color: #0f172a;
   margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
 `;
 
 export const UserEmail = styled.p`
-  ${typography.body1Regular};
-  color: ${colors.text.sub};
+  ${({ theme }) => theme.body1Regular};
+  color: #64748b;
   margin: 0;
+  font-size: 15px;
   word-break: break-all;
+  font-weight: 500;
 `;
 
-export const EmptyState = styled.p`
-  ${typography.body1Regular};
-  color: ${colors.text.sub};
+export const EmptyState = styled.div`
+  ${({ theme }) => theme.body1Regular};
+  color: #64748b;
   margin: 0;
+  padding: ${({ theme }) => theme.spacing8};
+  text-align: center;
+  background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+  border-radius: 20px;
+  font-size: 15px;
+  line-height: 1.6;
+
+  &::before {
+    content: '👤';
+    display: block;
+    font-size: 48px;
+    margin-bottom: ${({ theme }) => theme.spacing3};
+    opacity: 0.4;
+  }
 `;
 
 export const StatusList = styled.dl`
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: ${spacing.spacing3};
-  margin: 0;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: ${({ theme }) => theme.spacing3};
+  margin: ${({ theme }) => theme.spacing2} 0 0;
 `;
 
 export const StatusItem = styled.div`
   display: flex;
   flex-direction: column;
-  gap: ${spacing.spacing1};
-  padding: ${spacing.spacing3};
-  border-radius: 16px;
-  background-color: ${colors.background.fill};
-  border: 1px solid ${colors.border.default};
+  gap: ${({ theme }) => theme.spacing2};
+  padding: ${({ theme }) => theme.spacing4};
+  border-radius: 20px;
+  background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+  border: 1px solid #e2e8f0;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 3px;
+    background: linear-gradient(90deg, #3b82f6, #8b5cf6);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.3s ease;
+  }
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 16px rgba(59, 130, 246, 0.12);
+    border-color: #bfdbfe;
+
+    &::before {
+      transform: scaleX(1);
+    }
+  }
 `;
 
 export const StatusLabel = styled.dt`
-  ${typography.label1Regular};
-  color: ${colors.text.sub};
+  ${({ theme }) => theme.label1Regular};
+  color: #64748b;
   margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 `;
 
 export const StatusValue = styled.dd`
-  ${typography.title2Bold};
-  color: ${colors.text.default};
+  ${({ theme }) => theme.title2Bold};
+  color: #0f172a;
   margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
 `;
 
 export const Actions = styled.div`
   display: flex;
+  gap: ${({ theme }) => theme.spacing3};
   justify-content: flex-end;
-  margin-top: ${spacing.spacing4};
+  margin-top: ${({ theme }) => theme.spacing2};
+  flex-wrap: wrap;
 `;
 
 export const LogoutButton = styled.button`
-  padding: ${spacing.spacing2} ${spacing.spacing4};
-  border-radius: 9999px;
+  padding: ${({ theme }) => theme.spacing3} ${({ theme }) => theme.spacing6};
+  border-radius: 16px;
   border: none;
-  background-color: ${colors.blue[700]};
-  color: ${colors.gray[0]};
-  ${typography.body1Bold};
+  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+  color: white;
+  ${({ theme }) => theme.body1Bold};
+  font-size: 15px;
+  font-weight: 700;
   cursor: pointer;
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow:
+    0 4px 12px rgba(239, 68, 68, 0.25),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgba(255, 255, 255, 0.2),
+      transparent
+    );
+    background-size: 200% 100%;
+    animation: ${shimmer} 2s ease-in-out infinite;
+  }
 
   &:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(33, 124, 249, 0.25);
+    transform: translateY(-2px);
+    box-shadow:
+      0 8px 20px rgba(239, 68, 68, 0.35),
+      inset 0 1px 0 rgba(255, 255, 255, 0.15);
   }
 
   &:active {
     transform: translateY(0);
-    box-shadow: 0 2px 8px rgba(19, 95, 205, 0.35);
+    box-shadow:
+      0 2px 8px rgba(220, 38, 38, 0.4),
+      inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgba(239, 68, 68, 0.3);
+    outline-offset: 2px;
   }
 `;

--- a/src/pages/My/MyPage.tsx
+++ b/src/pages/My/MyPage.tsx
@@ -63,7 +63,10 @@ export default function MyPage() {
         <S.Heading>내 계정</S.Heading>
         {user ? (
           <>
-            <S.Avatar src={user.avatarUrl} alt={`${user.name} 아바타`} />
+            <S.AvatarWrapper>
+              <S.Avatar src={user.avatarUrl} alt={`${user.name} 아바타`} />
+              <S.AvatarBadge aria-hidden="true" />
+            </S.AvatarWrapper>
             <S.UserMeta>
               <S.UserName>{user.name}</S.UserName>
               <S.UserEmail>{user.email}</S.UserEmail>

--- a/src/pages/Onboarding/SportSelectPage.styled.ts
+++ b/src/pages/Onboarding/SportSelectPage.styled.ts
@@ -1,35 +1,116 @@
+import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const shimmer = keyframes`
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+`;
 
 export const Page = styled.main`
   display: grid;
   grid-template-rows: auto 1fr auto;
-  gap: ${({ theme }) => theme.spacing3};
   min-height: 100vh;
-  background: ${({ theme }) => theme.background.fill};
+  background: linear-gradient(180deg, #fefce8 0%, #fef3c7 50%, #fde68a 100%);
+  animation: ${fadeIn} 0.4s ease-out;
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 300px;
+    background: radial-gradient(
+      circle at 50% 0%,
+      rgba(251, 191, 36, 0.15) 0%,
+      transparent 70%
+    );
+    pointer-events: none;
+  }
 `;
 
 export const Content = styled.div`
-  display: grid;
-  gap: ${({ theme }) => theme.spacing3};
-  padding: ${({ theme }) => `${theme.spacing4} ${theme.spacing4}`};
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing5};
+  padding: ${({ theme }) =>
+    `${theme.spacing6} ${theme.spacing4} ${theme.spacing8}`};
+  max-width: 640px;
+  margin: 0 auto;
+  width: 100%;
+  position: relative;
+  z-index: 1;
+`;
+
+export const Header = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing2};
 `;
 
 export const SectionTitle = styled.h2`
   margin: 0;
-  color: ${({ theme }) => theme.text.default};
-  font-size: ${({ theme }) => theme.subtitle1Bold.fontSize};
-  font-weight: ${({ theme }) => theme.subtitle1Bold.fontWeight};
-  line-height: ${({ theme }) => theme.subtitle1Bold.lineHeight};
+  color: #78350f;
+  font-size: 28px;
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: -0.02em;
+  text-shadow: 0 1px 2px rgba(120, 53, 15, 0.05);
 `;
 
 export const SectionHint = styled.p`
   margin: 0;
-  color: ${({ theme }) => theme.text.placeholder};
-  font-size: ${({ theme }) => theme.label1Regular.fontSize};
-  line-height: ${({ theme }) => theme.label1Regular.lineHeight};
+  color: #92400e;
+  font-size: 15px;
+  line-height: 1.6;
+  font-weight: 500;
+  opacity: 0.9;
 `;
 
 export const List = styled.div`
   display: grid;
-  gap: ${({ theme }) => theme.spacing2};
+  gap: ${({ theme }) => theme.spacing3};
+`;
+
+export const LoadingShimmer = styled.div`
+  height: 80px;
+  border-radius: 16px;
+  background: linear-gradient(90deg, #fef3c7 0%, #fde68a 50%, #fef3c7 100%);
+  background-size: 200% 100%;
+  animation: ${shimmer} 1.5s ease-in-out infinite;
+`;
+
+export const EmptyState = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: ${({ theme }) => theme.spacing3};
+  padding: ${({ theme }) => theme.spacing8};
+  text-align: center;
+  color: #92400e;
+  font-size: 15px;
+  line-height: 1.6;
+
+  &::before {
+    content: '🏅';
+    font-size: 48px;
+    opacity: 0.6;
+  }
 `;

--- a/src/pages/Onboarding/SportSelectPage.tsx
+++ b/src/pages/Onboarding/SportSelectPage.tsx
@@ -61,12 +61,12 @@ export default function SportSelectPage() {
     <S.Page aria-label="sport-select-page">
       <OriginTitleBar title="원하는 종목 선택" onBack={handleBack} />
       <S.Content>
-        <div>
+        <S.Header>
           <S.SectionTitle>어떤 종목을 즐기시나요?</S.SectionTitle>
           <S.SectionHint>
             여러 개 선택 가능 · 최소 1개 이상 선택해 주세요.
           </S.SectionHint>
-        </div>
+        </S.Header>
 
         <S.List>
           {sports.map((sport) => (

--- a/src/pages/Onboarding/TimeSelectPage.styled.ts
+++ b/src/pages/Onboarding/TimeSelectPage.styled.ts
@@ -1,36 +1,98 @@
+import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
 
 export const Page = styled.main`
   display: grid;
   grid-template-rows: auto 1fr auto;
-  gap: ${({ theme }) => theme.spacing3};
   min-height: 100vh;
-  background: ${({ theme }) => theme.background.fill};
+  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+  animation: ${fadeIn} 0.4s ease-out;
 `;
 
 export const Content = styled.div`
-  display: grid;
-  gap: ${({ theme }) => theme.spacing3};
-  padding: ${({ theme }) => `${theme.spacing4} ${theme.spacing4}`};
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing5};
+  padding: ${({ theme }) =>
+    `${theme.spacing6} ${theme.spacing4} ${theme.spacing8}`};
+  max-width: 640px;
+  margin: 0 auto;
+  width: 100%;
+`;
+
+export const Header = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing2};
 `;
 
 export const SectionTitle = styled.h2`
   margin: 0;
   color: ${({ theme }) => theme.text.default};
-  font-size: ${({ theme }) => theme.subtitle1Bold.fontSize};
-  font-weight: ${({ theme }) => theme.subtitle1Bold.fontWeight};
-  line-height: ${({ theme }) => theme.subtitle1Bold.lineHeight};
+  font-size: 28px;
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, #0f172a 0%, #334155 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 `;
 
 export const SectionHint = styled.p`
   margin: 0;
-  color: ${({ theme }) => theme.text.placeholder};
-  font-size: ${({ theme }) => theme.label1Regular.fontSize};
-  line-height: ${({ theme }) => theme.label1Regular.lineHeight};
+  color: ${({ theme }) => theme.text.sub};
+  font-size: 15px;
+  line-height: 1.6;
+  font-weight: 500;
+  opacity: 0.8;
 `;
 
 export const Grid = styled.div`
   display: grid;
   grid-template-columns: repeat(2, 1fr);
+  gap: ${({ theme }) => theme.spacing3};
+
+  @media (max-width: 380px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const ProgressIndicator = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
   gap: ${({ theme }) => theme.spacing2};
+  padding: ${({ theme }) => theme.spacing4};
+  margin: 0 auto;
+  max-width: 200px;
+`;
+
+export const ProgressDot = styled.div<{ active?: boolean }>`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: ${({ active, theme }) =>
+    active
+      ? 'linear-gradient(135deg, #3B82F6 0%, #2563EB 100%)'
+      : theme.text.placeholder};
+  opacity: ${({ active }) => (active ? 1 : 0.3)};
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+
+  ${({ active }) =>
+    active &&
+    `
+    box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+  `}
 `;

--- a/src/pages/Onboarding/TimeSelectPage.tsx
+++ b/src/pages/Onboarding/TimeSelectPage.tsx
@@ -48,12 +48,12 @@ export default function TimeSelectPage() {
     <S.Page aria-label="time-select-page">
       <OriginTitleBar title="운동 가능한 시간대 선택" onBack={handleBack} />
       <S.Content>
-        <div>
+        <S.Header>
           <S.SectionTitle>어떤 시간대를 원하나요?</S.SectionTitle>
           <S.SectionHint>
             여러 개 선택 가능 · 최소 1개 이상 선택해 주세요.
           </S.SectionHint>
-        </div>
+        </S.Header>
 
         <S.Grid>
           {SLOTS.map((slot) => (
@@ -67,6 +67,11 @@ export default function TimeSelectPage() {
             />
           ))}
         </S.Grid>
+
+        <S.ProgressIndicator aria-label="온보딩 진행 상황">
+          <S.ProgressDot active />
+          <S.ProgressDot active />
+        </S.ProgressIndicator>
       </S.Content>
 
       <PageActions


### PR DESCRIPTION
## Summary
- redesign the selection card component with richer visuals and animations
- refresh the sticky onboarding action bar with shimmer effects and improved accessibility
- update onboarding and my page layouts to match the new gradient-driven aesthetic and status cards

## Testing
- npm run lint
- npx vitest run src/tests/onboarding/onboardingFlow.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_690c45199fb08332a0dceb0f48d893eb