### PR TITLE
Fix vendor form utilities typing issues

### DIFF
--- a/src/pages/Forms/ProfileFormDemo.tsx
+++ b/src/pages/Forms/ProfileFormDemo.tsx
@@ -1,5 +1,5 @@
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useForm } from 'react-hook-form';
+import { zodResolver } from '@form-kit/hookform-resolvers/zod-lite';
+import { useForm } from '@form-kit/react-hook-form-lite';
 
 import TextField from '@/components/form/TextField';
 import RouteSkeleton from '@/components/RouteSkeleton';

--- a/src/tests/ui/profileForm.a11y.test.tsx
+++ b/src/tests/ui/profileForm.a11y.test.tsx
@@ -92,8 +92,8 @@ describe('ProfileFormDemo 접근성', () => {
   it('초기화 버튼으로 값과 에러 상태를 재설정', async () => {
     renderForm();
 
-    const nickname = screen.getByLabelText('닉네임');
-    const email = screen.getByLabelText('이메일');
+    const nickname = screen.getByLabelText<HTMLInputElement>('닉네임');
+    const email = screen.getByLabelText<HTMLInputElement>('이메일');
 
     fireEvent.change(nickname, { target: { value: '홍길동' } });
     fireEvent.change(email, { target: { value: 'invalid-email' } });

--- a/src/vendor/hookform-resolvers/zod.ts
+++ b/src/vendor/hookform-resolvers/zod.ts
@@ -23,7 +23,7 @@ export const zodResolver = <
 >(
   schema: ZodSchema<TOutput>,
 ): Resolver<TFieldValues> => {
-  return (values) => {
+  return (values: TFieldValues) => {
     const result = schema.safeParse(values);
 
     if (result.success) {

--- a/src/vendor/zod.ts
+++ b/src/vendor/zod.ts
@@ -59,11 +59,16 @@ abstract class ZodType<T> {
 }
 
 class ZodString extends ZodType<string> {
+  private readonly preprocessors: ((value: string) => string)[];
+  private readonly checks: Check<string>[];
+
   constructor(
-    private readonly preprocessors: ((value: string) => string)[] = [],
-    private readonly checks: Check<string>[] = [],
+    preprocessors: ((value: string) => string)[] = [],
+    checks: Check<string>[] = [],
   ) {
     super();
+    this.preprocessors = preprocessors;
+    this.checks = checks;
   }
 
   _parse(data: unknown, path: (string | number)[]): ParseResult<string> {
@@ -172,8 +177,11 @@ class ZodString extends ZodType<string> {
 }
 
 class ZodLiteral<T extends string | number | boolean> extends ZodType<T> {
-  constructor(private readonly expected: T) {
+  private readonly expected: T;
+
+  constructor(expected: T) {
     super();
+    this.expected = expected;
   }
 
   _parse(data: unknown, path: (string | number)[]): ParseResult<T> {
@@ -190,8 +198,11 @@ class ZodLiteral<T extends string | number | boolean> extends ZodType<T> {
 }
 
 class ZodOptional<T> extends ZodType<T | undefined> {
-  constructor(private readonly inner: ZodType<T>) {
+  private readonly inner: ZodType<T>;
+
+  constructor(inner: ZodType<T>) {
     super();
+    this.inner = inner;
   }
 
   _parse(data: unknown, path: (string | number)[]): ParseResult<T | undefined> {
@@ -207,8 +218,11 @@ type UnionOptions = readonly ZodType<unknown>[];
 class ZodUnion<TOptions extends UnionOptions> extends ZodType<
   TOptions[number]['_output']
 > {
-  constructor(private readonly options: TOptions) {
+  private readonly options: TOptions;
+
+  constructor(options: TOptions) {
     super();
+    this.options = options;
   }
 
   _parse(
@@ -239,8 +253,11 @@ type ObjectOutput<T extends Shape> = {
 };
 
 class ZodObject<T extends Shape> extends ZodType<ObjectOutput<T>> {
-  constructor(private readonly shape: T) {
+  private readonly shape: T;
+
+  constructor(shape: T) {
     super();
+    this.shape = shape;
   }
 
   _parse(


### PR DESCRIPTION
## Summary
- adjust the vendor react-hook-form shim to avoid parameter properties and align with strict typing expectations
- ensure the lightweight zod resolver and schema implementations are compatible with the exported resolver type
- fix the profile form accessibility test to treat labeled elements as inputs when asserting values

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690c6b785264833282e7382d8840d103