### PR TITLE
Fix Kakao callback redirect URI handling

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -122,15 +122,22 @@ export async function getKakaoOAuthUrl(params?: {
   return extractAuthUrl(data);
 }
 
-export async function exchangeKakaoCode(code: string): Promise<{
+export async function exchangeKakaoCode(
+  code: string,
+  redirectUri?: string,
+): Promise<{
   token: string | null;
   accessToken: string | null;
   refreshToken: string | null;
 }> {
+  const params: Record<string, string> = { code };
+  if (redirectUri) {
+    params.redirectUri = redirectUri;
+  }
   const { data } = await apiClient.get<NestedAuthResponse>(
     '/api/v1/auth/kakao/callback',
     {
-      params: { code },
+      params,
     },
   );
 

--- a/src/features/auth/services/kakao.ts
+++ b/src/features/auth/services/kakao.ts
@@ -47,7 +47,14 @@ export async function handleKakaoCallback({
   }
 
   try {
-    const { token, accessToken, refreshToken } = await exchangeKakaoCode(code);
+    const redirectUri =
+      typeof window !== 'undefined'
+        ? `${window.location.origin}/auth/kakao/callback`
+        : undefined;
+    const { token, accessToken, refreshToken } = await exchangeKakaoCode(
+      code,
+      redirectUri,
+    );
     const sessionToken = accessToken ?? token ?? null;
 
     if (!sessionToken) {

--- a/src/pages/Auth/KakaoCallbackPage.tsx
+++ b/src/pages/Auth/KakaoCallbackPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import RouteSkeleton from '@/components/RouteSkeleton';
@@ -13,11 +13,18 @@ export default function KakaoCallbackPage() {
   const appHydrated = useHasHydrated();
   const sessionHydrated = useSessionHydrated();
   const navigate = useNavigate();
+  const onceRef = useRef(false);
 
   useEffect(() => {
     if (!appHydrated || !sessionHydrated) {
       return;
     }
+
+    if (onceRef.current) {
+      return;
+    }
+
+    onceRef.current = true;
 
     void (async () => {
       const { to, options } = await handleKakaoCallback({ code, state });


### PR DESCRIPTION
## Summary
- ensure the Kakao code exchange request forwards the callback redirectUri when available
- reuse the same redirect URI during Kakao callback handling and prevent duplicate effect execution

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690c8fc7ce5c83329762d6521fc1deac