### PR TITLE
feat(profile): add query/mutation hooks with optimistic updates

### DIFF
--- a/docs/profile-cache-keys.md
+++ b/docs/profile-cache-keys.md
@@ -1,0 +1,30 @@
+# Profile Cache Keys & Invalidation
+
+## Keys
+
+- `PROFILE_QUERY_ROOT = ['profile']`
+- `PROFILE_ME_KEY = ['profile', 'me']`
+
+## Invalidation
+
+- 프로필 정보 수정 성공/실패와 관계없이 `onSettled` 단계에서 `invalidate(PROFILE_ME_KEY)`를 호출해 서버 상태를 재검증합니다.
+- 성공 시에는 곧바로 `setQueryData(PROFILE_ME_KEY, server)`로 최신 응답을 반영해 UI와 캐시의 일관성을 보장합니다.
+
+## Staleness Strategy
+
+- `staleTime = 60s` : 모바일 환경에서 뒤로가기/재진입 시 불필요한 네트워크 요청을 줄이고 즉시 응답성을 확보합니다.
+- `gcTime = 5m` : 사용자가 페이지를 떠난 뒤에도 짧은 시간 동안 캐시를 보존해 재방문 경험을 개선합니다.
+- `refetchOnWindowFocus = false` : 온보딩 · 마이페이지 플로우에서 불필요한 포커스 리패치를 방지합니다.
+
+## Optimistic Update Pattern
+
+1. `cancelQueries(PROFILE_ME_KEY)`로 진행 중인 요청을 중단합니다.
+2. 직전 스냅샷을 보관하고 `setQueryData`로 낙관적 상태를 구성합니다.
+3. 실패 시 스냅샷과 Zustand `user` 스토어를 모두 롤백한 뒤 오류 토스트를 노출합니다.
+4. 성공 시 서버 응답을 캐시에 반영하고 `notify.success`로 피드백을 제공합니다.
+5. 마지막으로 `invalidate`를 호출해 서버와의 정합성을 확정합니다.
+
+## Store Synchronization
+
+- `useProfileQuery`는 성공 시 `appStore.setUser`를 호출해 내비게이션/헤더 등 공용 UI에 즉시 반영합니다.
+- `useUpdateProfile`는 낙관적 단계에서 스토어까지 함께 갱신해 업로더·마이페이지 카드 등 다른 컴포넌트도 동시에 업데이트됩니다.

--- a/src/features/profile/keys.ts
+++ b/src/features/profile/keys.ts
@@ -1,0 +1,8 @@
+export const PROFILE_QUERY_ROOT = ['profile'] as const;
+
+export const PROFILE_ME_KEY = [...PROFILE_QUERY_ROOT, 'me'] as const;
+
+export const PROFILE_KEYS = {
+  root: PROFILE_QUERY_ROOT,
+  me: PROFILE_ME_KEY,
+} as const;

--- a/src/hooks/queries/profile/index.ts
+++ b/src/hooks/queries/profile/index.ts
@@ -1,1 +1,2 @@
 export * from './useMyProfileQuery';
+export * from './useProfileQuery';

--- a/src/hooks/queries/profile/useMyProfileQuery.ts
+++ b/src/hooks/queries/profile/useMyProfileQuery.ts
@@ -1,14 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
+import { PROFILE_ME_KEY } from '@/features/profile/keys';
 
-import { getMyProfile, type ProfileResponse } from '@/api/profile';
+import { useProfileQuery } from './useProfileQuery';
 
-export const myProfileQueryKey = ['profile', 'me'] as const;
+export const myProfileQueryKey = PROFILE_ME_KEY;
 
 export function useMyProfileQuery(enabled = true) {
-  return useQuery<ProfileResponse>({
-    queryKey: myProfileQueryKey,
-    queryFn: getMyProfile,
-    enabled,
-    staleTime: 60 * 1000,
-  });
+  return useProfileQuery({ enabled });
 }

--- a/src/hooks/queries/profile/useProfileQuery.ts
+++ b/src/hooks/queries/profile/useProfileQuery.ts
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+import { getMyProfile, type ProfileResponse } from '@/api/profile';
+import { PROFILE_ME_KEY } from '@/features/profile/keys';
+import { useActions, useAppStore, type User } from '@/stores/appStore';
+
+type UseProfileQueryOptions = {
+  enabled?: boolean;
+};
+
+export function useProfileQuery(options: UseProfileQueryOptions = {}) {
+  const { setUser } = useActions();
+
+  const query = useQuery<ProfileResponse>({
+    queryKey: PROFILE_ME_KEY,
+    queryFn: getMyProfile,
+    enabled: options.enabled ?? true,
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  useEffect(() => {
+    if (!query.data) return;
+
+    const profile: ProfileResponse = query.data;
+    const currentUser = useAppStore.getState().user;
+    const id = currentUser?.id ?? 0;
+    const nextUser: User = {
+      id,
+      name: profile.name,
+      email: profile.email,
+      avatarUrl: profile.imageUrl,
+    };
+
+    setUser(nextUser);
+  }, [query.data, setUser]);
+
+  return query;
+}

--- a/src/pages/My/MyPage.tsx
+++ b/src/pages/My/MyPage.tsx
@@ -5,8 +5,8 @@ import { queryClient } from '@/api/core/queryClient';
 import { updateMyProfileImageUrl } from '@/api/profile';
 import RouteSkeleton from '@/components/RouteSkeleton';
 import OriginTitleBar from '@/components/titleBar/originTitleBar';
+import { PROFILE_ME_KEY } from '@/features/profile/keys';
 import ImageUploader from '@/features/upload/components/ImageUploader';
-import { myProfileQueryKey } from '@/hooks/queries/profile/useMyProfileQuery';
 import {
   useCurrentUser,
   useEmailVerified,
@@ -66,7 +66,7 @@ export default function MyPage() {
         if (user) {
           setUser({ ...user, avatarUrl: url });
         }
-        await queryClient.invalidateQueries({ queryKey: myProfileQueryKey });
+        await queryClient.invalidateQueries({ queryKey: PROFILE_ME_KEY });
       } catch (error) {
         console.error('프로필 이미지 업데이트 실패', error);
       }

--- a/src/pages/My/ProfileEditPage.tsx
+++ b/src/pages/My/ProfileEditPage.tsx
@@ -5,11 +5,11 @@ import { type ProfileResponse, type UpdateProfileRequest } from '@/api/profile';
 import RouteSkeleton from '@/components/RouteSkeleton';
 import OriginTitleBar from '@/components/titleBar/originTitleBar';
 import { ProfileForm } from '@/features/profile/components/ProfileForm';
-import { useUpdateMyProfileMutation } from '@/hooks/mutations/profile';
-import { useMyProfileQuery } from '@/hooks/queries/profile';
+import { useUpdateProfile } from '@/hooks/mutations/profile';
+import { useProfileQuery } from '@/hooks/queries/profile';
 import type { ProfileFormValues } from '@/libs/validation/zodSchemas';
 import { notify } from '@/pages/notifications/notify';
-import { useHasHydrated, useActions, useCurrentUser } from '@/stores/appStore';
+import { useHasHydrated } from '@/stores/appStore';
 
 import * as S from './ProfileEditPage.styled';
 
@@ -23,11 +23,14 @@ const toFormValues = (profile: ProfileResponse): ProfileFormValues => ({
 export default function ProfileEditPage() {
   const hasHydrated = useHasHydrated();
   const navigate = useNavigate();
-  const { data: profile, isLoading, isError } = useMyProfileQuery(hasHydrated);
-  const { mutateAsync: updateProfile, isPending } =
-    useUpdateMyProfileMutation();
-  const { setUser } = useActions();
-  const currentUser = useCurrentUser();
+  const {
+    data: profile,
+    isLoading,
+    isError,
+  } = useProfileQuery({
+    enabled: hasHydrated,
+  });
+  const { mutateAsync: updateProfile, isPending } = useUpdateProfile();
   const [previewUrl, setPreviewUrl] = useState<string | undefined>();
   const [previewName, setPreviewName] = useState('');
 
@@ -78,21 +81,12 @@ export default function ProfileEditPage() {
       }
 
       try {
-        const updated = await updateProfile(request);
-        if (currentUser) {
-          setUser({
-            ...currentUser,
-            name: updated.name,
-            email: updated.email,
-            avatarUrl: updated.imageUrl,
-          });
-        }
-        notify.success('프로필이 업데이트되었어요!');
+        await updateProfile(request);
       } catch {
-        notify.error('프로필을 저장하지 못했어요. 잠시 후 다시 시도해 주세요.');
+        // 훅 내부에서 토스트 및 롤백을 처리합니다.
       }
     },
-    [currentUser, profile, setUser, updateProfile],
+    [profile, updateProfile],
   );
 
   const handleFormChange = useCallback((values: ProfileFormValues) => {

--- a/src/tests/profile/useUpdateProfile.test.tsx
+++ b/src/tests/profile/useUpdateProfile.test.tsx
@@ -1,0 +1,120 @@
+/* @vitest-environment jsdom */
+
+import { ThemeProvider } from '@emotion/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useUpdateProfile } from '@/hooks/mutations/profile';
+import { useProfileQuery } from '@/hooks/queries/profile';
+import { resetProfileState } from '@/mocks/handlers/profile';
+import { server } from '@/mocks/server';
+import { registerNotifier } from '@/pages/notifications/notify';
+import { useAppStore } from '@/stores/appStore';
+import { theme } from '@/theme';
+
+function ProfileHarness() {
+  const { data } = useProfileQuery();
+  const mutation = useUpdateProfile();
+
+  return (
+    <div>
+      <span aria-label="profile-name">{data?.name ?? ''}</span>
+      <button type="button" onClick={() => mutation.mutate({ name: '홍길동' })}>
+        update-success
+      </button>
+      <button type="button" onClick={() => mutation.mutate({ name: '실패' })}>
+        update-fail
+      </button>
+    </div>
+  );
+}
+
+const renderWithProviders = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: 0 },
+      mutations: { retry: 0 },
+    },
+  });
+
+  return render(
+    <ThemeProvider theme={theme}>
+      <QueryClientProvider client={queryClient}>
+        <ProfileHarness />
+      </QueryClientProvider>
+    </ThemeProvider>,
+  );
+};
+
+describe('useUpdateProfile', () => {
+  const success = vi.fn();
+  const error = vi.fn();
+
+  beforeEach(() => {
+    resetProfileState();
+    window.localStorage.clear();
+    useAppStore.getState().actions.resetAll();
+    registerNotifier({
+      success,
+      error,
+      info: vi.fn(),
+      warning: vi.fn(),
+    });
+    success.mockReset();
+    error.mockReset();
+  });
+
+  it('낙관적 업데이트 후 성공 응답을 확정한다', async () => {
+    renderWithProviders();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('profile-name').textContent).not.toBe('');
+    });
+
+    fireEvent.click(screen.getByText('update-success'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('profile-name').textContent).toBe('홍길동');
+    });
+
+    expect(success).toHaveBeenCalledWith('저장 완료!');
+
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('실패 시 낙관적 상태를 롤백하고 에러 토스트를 노출한다', async () => {
+    server.use(
+      http.patch('*/api/v2/members/me/profile/name', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return HttpResponse.json('error', { status: 500 });
+      }),
+    );
+
+    renderWithProviders();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('profile-name').textContent).not.toBe('');
+    });
+
+    const initialName = screen.getByLabelText('profile-name').textContent ?? '';
+
+    fireEvent.click(screen.getByText('update-fail'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('profile-name').textContent).toBe('실패');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('profile-name').textContent).toBe(
+        initialName,
+      );
+      expect(error).toHaveBeenCalledWith(
+        '저장에 실패했어요. 네트워크 상태를 확인해 주세요.',
+      );
+    });
+
+    expect(success).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/ui/profileEdit.a11y.test.tsx
+++ b/src/tests/ui/profileEdit.a11y.test.tsx
@@ -149,7 +149,7 @@ describe('ProfileEditPage 접근성 및 상호작용', () => {
     await waitForReactQueryIdle();
 
     await waitFor(() => {
-      expect(notify.success).toHaveBeenCalledWith('프로필이 업데이트되었어요!');
+      expect(notify.success).toHaveBeenCalledWith('저장 완료!');
     });
 
     await waitFor(() => {
@@ -217,7 +217,7 @@ describe('ProfileEditPage 접근성 및 상호작용', () => {
     await waitForReactQueryIdle();
 
     await waitFor(() => {
-      expect(notify.success).toHaveBeenCalledWith('프로필이 업데이트되었어요!');
+      expect(notify.success).toHaveBeenCalledWith('저장 완료!');
     });
   });
 });


### PR DESCRIPTION
## Summary
- centralize profile cache keys and add `useProfileQuery` that syncs the Zustand user store
- implement `useUpdateProfile` with optimistic updates, rollback, notifications, and reuse it in My pages
- document the cache strategy and add unit tests for optimistic success/failure flows

## Testing
- npm run lint
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_690c90f5007c8332a73f9587f3a0c440