### PR TITLE
Improve profile edit UX and certification flows

### DIFF
--- a/src/api/certification.ts
+++ b/src/api/certification.ts
@@ -2,9 +2,18 @@ import { apiClient } from '@/api/core/axiosInstance';
 
 export type CertificationStatusResponse = { isVerified: boolean };
 
-export type CertificationEmailRequest = { localPart: string };
+export type CertificationEmailRequest = {
+  email: string;
+  localPart?: string;
+  domain?: string;
+};
 
-export type CertificationVerifyRequest = { localPart: string; code: string };
+export type CertificationVerifyRequest = {
+  email: string;
+  code: string;
+  localPart?: string;
+  domain?: string;
+};
 
 export async function getCertificationStatus() {
   const { data } = await apiClient.get<CertificationStatusResponse>(
@@ -14,19 +23,46 @@ export async function getCertificationStatus() {
   return data;
 }
 
-export async function requestCertificationEmail(localPart: string) {
+export async function requestCertificationEmail(
+  request: CertificationEmailRequest,
+) {
+  const payload: CertificationEmailRequest = {
+    email: request.email.trim(),
+  };
+
+  if (request.localPart) {
+    payload.localPart = request.localPart.trim();
+  }
+
+  if (request.domain) {
+    payload.domain = request.domain.trim();
+  }
+
   const { data } = await apiClient.post<CertificationStatusResponse>(
     '/api/v1/members/me/certification/email',
-    { localPart } satisfies CertificationEmailRequest,
+    payload,
   );
 
   return data;
 }
 
-export async function verifyCertification(localPart: string, code: string) {
+export async function verifyCertification(request: CertificationVerifyRequest) {
+  const payload: CertificationVerifyRequest = {
+    email: request.email.trim(),
+    code: request.code.trim(),
+  };
+
+  if (request.localPart) {
+    payload.localPart = request.localPart.trim();
+  }
+
+  if (request.domain) {
+    payload.domain = request.domain.trim();
+  }
+
   const { data } = await apiClient.post<CertificationStatusResponse>(
     '/api/v1/members/me/certification/verify',
-    { localPart, code } satisfies CertificationVerifyRequest,
+    payload,
   );
 
   return data;

--- a/src/components/form/TextField.styled.ts
+++ b/src/components/form/TextField.styled.ts
@@ -3,7 +3,10 @@ import styled from '@emotion/styled';
 
 import type { Theme } from '@/theme';
 
-export const Field = styled.div<{ invalid?: boolean; disabled?: boolean }>`
+export const Field = styled.div<{
+  invalid?: boolean;
+  disabled?: boolean;
+}>`
   display: grid;
   gap: ${({ theme }) => theme.spacing2};
   padding: ${({ theme }) => `${theme.spacing3} ${theme.spacing4}`};
@@ -25,6 +28,15 @@ export const Field = styled.div<{ invalid?: boolean; disabled?: boolean }>`
     box-shadow 0.2s ease,
     transform 0.2s ease;
   opacity: ${({ disabled }) => (disabled ? 0.75 : 1)};
+
+  &[data-clickable='true'] {
+    cursor: pointer;
+  }
+
+  &[data-clickable='true'] input,
+  &[data-clickable='true'] textarea {
+    cursor: pointer;
+  }
 
   &:focus-within {
     border-color: ${({ theme }) => theme.blue[500]};
@@ -61,6 +73,7 @@ const interactiveField = ({ theme }: { theme: Theme }) => css`
   font-weight: ${theme.body1Regular.fontWeight};
   line-height: ${theme.body1Regular.lineHeight};
   min-height: 40px;
+  min-width: 0;
   transition:
     color 0.2s ease,
     background-color 0.2s ease,
@@ -91,12 +104,67 @@ const interactiveField = ({ theme }: { theme: Theme }) => css`
 
 export const Input = styled.input`
   ${({ theme }) => interactiveField({ theme })};
+  flex: 1 1 auto;
 `;
 
 export const TextArea = styled.textarea`
   ${({ theme }) => interactiveField({ theme })};
   min-height: 132px;
   resize: vertical;
+  flex: 1 1 auto;
+`;
+
+export const InputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing2};
+`;
+
+export const Suffix = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing1};
+`;
+
+export const ClearButton = styled.button`
+  border: 0;
+  border-radius: 9999px;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(148, 163, 184, 0.18);
+  color: ${({ theme }) => theme.text.sub};
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    background: rgba(37, 99, 235, 0.16);
+    color: ${({ theme }) => theme.text.default};
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgba(37, 99, 235, 0.32);
+    outline-offset: 2px;
+    transform: translateY(-1px);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:focus-visible {
+      transform: none;
+    }
+  }
 `;
 
 export const Hint = styled.p`

--- a/src/components/form/TextField.tsx
+++ b/src/components/form/TextField.tsx
@@ -2,7 +2,12 @@ import type {
   FieldErrors,
   UseFormRegisterReturn,
 } from '@form-kit/react-hook-form-lite';
-import type { InputHTMLAttributes } from 'react';
+import type {
+  InputHTMLAttributes,
+  KeyboardEventHandler,
+  MouseEventHandler,
+  ReactNode,
+} from 'react';
 
 import { getAriaFor, makeIds } from '@/libs/a11y/formA11y';
 
@@ -20,6 +25,11 @@ type TextFieldProps = {
   autoComplete?: string;
   disabled?: boolean;
   readOnly?: boolean;
+  suffix?: ReactNode;
+  onContainerClick?: () => void;
+  clickable?: boolean;
+  onInputKeyDown?: KeyboardEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+  onInputClick?: MouseEventHandler<HTMLInputElement | HTMLTextAreaElement>;
 };
 
 export default function TextField({
@@ -34,6 +44,11 @@ export default function TextField({
   autoComplete,
   disabled = false,
   readOnly = false,
+  suffix,
+  onContainerClick,
+  clickable = false,
+  onInputKeyDown,
+  onInputClick,
 }: TextFieldProps) {
   const { inputId, errorId, hintId } = makeIds(name);
   const ariaProps = getAriaFor(name, errors, hint ? hintId : undefined);
@@ -47,9 +62,20 @@ export default function TextField({
   const resolvedAutoComplete =
     autoComplete ?? (type === 'email' ? 'email' : 'off');
   const resolvedInputMode = type === 'email' ? 'email' : undefined;
+  const containerClickable = Boolean(
+    clickable && !disabled && onContainerClick,
+  );
 
   return (
-    <S.Field invalid={invalid} disabled={disabled}>
+    <S.Field
+      invalid={invalid}
+      disabled={disabled}
+      data-clickable={containerClickable ? 'true' : undefined}
+      onClick={() => {
+        if (!containerClickable || !onContainerClick) return;
+        onContainerClick();
+      }}
+    >
       <S.Label htmlFor={inputId}>{label}</S.Label>
       {as === 'textarea' ? (
         <S.TextArea
@@ -67,27 +93,66 @@ export default function TextField({
           aria-readonly={readOnly || undefined}
           autoCorrect="off"
           autoCapitalize="none"
+          onKeyDown={
+            onInputKeyDown as KeyboardEventHandler<HTMLTextAreaElement>
+          }
+          onClick={onInputClick as MouseEventHandler<HTMLTextAreaElement>}
         />
       ) : (
-        <S.Input
-          id={inputId}
-          name={fieldName}
-          type={type}
-          onBlur={onBlur}
-          onChange={onChange}
-          ref={ref}
-          aria-invalid={ariaInvalid}
-          aria-describedby={ariaDescribedBy}
-          aria-errormessage={invalid ? ariaErrorMessage : undefined}
-          placeholder={placeholder}
-          autoComplete={resolvedAutoComplete}
-          inputMode={resolvedInputMode}
-          disabled={disabled}
-          readOnly={readOnly}
-          aria-readonly={readOnly || undefined}
-          autoCorrect="off"
-          autoCapitalize="none"
-        />
+        <>
+          {suffix ? (
+            <S.InputWrapper>
+              <S.Input
+                id={inputId}
+                name={fieldName}
+                type={type}
+                onBlur={onBlur}
+                onChange={onChange}
+                ref={ref}
+                aria-invalid={ariaInvalid}
+                aria-describedby={ariaDescribedBy}
+                aria-errormessage={invalid ? ariaErrorMessage : undefined}
+                placeholder={placeholder}
+                autoComplete={resolvedAutoComplete}
+                inputMode={resolvedInputMode}
+                disabled={disabled}
+                readOnly={readOnly}
+                aria-readonly={readOnly || undefined}
+                autoCorrect="off"
+                autoCapitalize="none"
+                onKeyDown={
+                  onInputKeyDown as KeyboardEventHandler<HTMLInputElement>
+                }
+                onClick={onInputClick as MouseEventHandler<HTMLInputElement>}
+              />
+              <S.Suffix>{suffix}</S.Suffix>
+            </S.InputWrapper>
+          ) : (
+            <S.Input
+              id={inputId}
+              name={fieldName}
+              type={type}
+              onBlur={onBlur}
+              onChange={onChange}
+              ref={ref}
+              aria-invalid={ariaInvalid}
+              aria-describedby={ariaDescribedBy}
+              aria-errormessage={invalid ? ariaErrorMessage : undefined}
+              placeholder={placeholder}
+              autoComplete={resolvedAutoComplete}
+              inputMode={resolvedInputMode}
+              disabled={disabled}
+              readOnly={readOnly}
+              aria-readonly={readOnly || undefined}
+              autoCorrect="off"
+              autoCapitalize="none"
+              onKeyDown={
+                onInputKeyDown as KeyboardEventHandler<HTMLInputElement>
+              }
+              onClick={onInputClick as MouseEventHandler<HTMLInputElement>}
+            />
+          )}
+        </>
       )}
       {hint && <S.Hint id={hintId}>{hint}</S.Hint>}
       {invalid && (

--- a/src/features/profile/components/ProfileForm/ProfileForm.styled.ts
+++ b/src/features/profile/components/ProfileForm/ProfileForm.styled.ts
@@ -170,3 +170,46 @@ export const SecondaryButton = styled.button`
     outline-offset: 3px;
   }
 `;
+
+export const ImageUrlClearButton = styled.button`
+  border: 0;
+  border-radius: 9999px;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.06);
+  color: ${({ theme }) => theme.text.sub};
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    background: rgba(37, 99, 235, 0.16);
+    color: ${({ theme }) => theme.text.default};
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgba(37, 99, 235, 0.32);
+    outline-offset: 2px;
+    transform: translateY(-1px);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:focus-visible {
+      transform: none;
+    }
+  }
+`;

--- a/src/features/profile/components/ProfileForm/ProfileForm.tsx
+++ b/src/features/profile/components/ProfileForm/ProfileForm.tsx
@@ -1,6 +1,12 @@
 import { zodResolver } from '@form-kit/hookform-resolvers/zod-lite';
 import { useForm } from '@form-kit/react-hook-form-lite';
-import { useCallback, useEffect, useId, useMemo } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  type KeyboardEvent,
+} from 'react';
 
 import TextField from '@/components/form/TextField';
 import {
@@ -54,6 +60,9 @@ export type ProfileFormProps = {
   cancelLabel?: string;
   onChange?: (values: ProfileFormValues) => void;
   onImageUploaded?: (imageUrl: string) => Promise<void> | void;
+  emailFieldHint?: string;
+  onEmailFieldClick?: () => void;
+  emailFieldInteractive?: boolean;
 };
 
 export default function ProfileForm({
@@ -65,6 +74,9 @@ export default function ProfileForm({
   cancelLabel = '취소',
   onChange,
   onImageUploaded,
+  emailFieldHint,
+  onEmailFieldClick,
+  emailFieldInteractive = false,
 }: ProfileFormProps) {
   const memoizedInitial = useMemo(
     () => deriveInitialValues(initialValues),
@@ -113,16 +125,48 @@ export default function ProfileForm({
 
   const busy = submitting || isSubmitting;
   const directUploadId = useId();
+  const imageUrlValue = form.watch('imageUrl') as
+    | ProfileFormValues['imageUrl']
+    | string[]
+    | undefined;
+  const normalizedImageUrl = Array.isArray(imageUrlValue)
+    ? (imageUrlValue[0] ?? '')
+    : (imageUrlValue ?? '');
+  const trimmedImageUrl = normalizedImageUrl.trim();
+  const emailHint = emailFieldHint ?? '학교 인증된 이메일';
+  const emailClickable = emailFieldInteractive && !busy;
 
   const handleImageUploaded = useCallback(
     (url: string) => {
       const trimmed = url.trim();
       if (!trimmed) return;
 
-      setValue('imageUrl', trimmed);
+      setValue('imageUrl', trimmed, {
+        shouldDirty: true,
+        shouldTouch: true,
+        shouldValidate: true,
+      });
       void onImageUploaded?.(trimmed);
     },
     [onImageUploaded, setValue],
+  );
+
+  const handleClearImageUrl = useCallback(() => {
+    setValue('imageUrl', '', {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate: true,
+    });
+  }, [setValue]);
+
+  const handleEmailKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (!onEmailFieldClick) return;
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      event.preventDefault();
+      onEmailFieldClick();
+    },
+    [onEmailFieldClick],
   );
 
   const handleCancel = () => {
@@ -151,12 +195,15 @@ export default function ProfileForm({
         <TextField
           name="email"
           label="이메일"
-          hint="학교 인증된 이메일"
+          hint={emailHint}
           register={register('email')}
           errors={errors}
           type="email"
           readOnly
           disabled={busy}
+          clickable={emailClickable}
+          onContainerClick={emailClickable ? onEmailFieldClick : undefined}
+          onInputKeyDown={emailClickable ? handleEmailKeyDown : undefined}
         />
 
         <TextField
@@ -172,12 +219,26 @@ export default function ProfileForm({
         <TextField
           name="imageUrl"
           label="프로필 이미지 URL"
-          hint="https:// 로 시작하는 주소"
+          hint="이미지 주소를 입력해 주세요."
           register={register('imageUrl')}
           errors={errors}
           type="url"
           disabled={busy}
           autoComplete="off"
+          suffix={
+            trimmedImageUrl ? (
+              <S.ImageUrlClearButton
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  handleClearImageUrl();
+                }}
+                aria-label="프로필 이미지 URL 지우기"
+              >
+                ✕
+              </S.ImageUrlClearButton>
+            ) : undefined
+          }
         />
 
         <S.DirectUploadCard

--- a/src/hooks/mutations/certification/useSendCertificationEmail.ts
+++ b/src/hooks/mutations/certification/useSendCertificationEmail.ts
@@ -1,9 +1,13 @@
 import { useMutation } from '@tanstack/react-query';
 
-import { requestCertificationEmail } from '@/api/certification';
+import {
+  requestCertificationEmail,
+  type CertificationEmailRequest,
+} from '@/api/certification';
 
 export function useSendCertificationEmail() {
   return useMutation({
-    mutationFn: (localPart: string) => requestCertificationEmail(localPart),
+    mutationFn: (payload: CertificationEmailRequest) =>
+      requestCertificationEmail(payload),
   });
 }

--- a/src/hooks/mutations/certification/useVerifyCertification.ts
+++ b/src/hooks/mutations/certification/useVerifyCertification.ts
@@ -1,6 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { verifyCertification } from '@/api/certification';
+import {
+  verifyCertification,
+  type CertificationVerifyRequest,
+} from '@/api/certification';
 import { CERTIFICATION_STATUS_KEY } from '@/hooks/queries/certification/useCertificationStatus';
 import { useActions } from '@/stores/appStore';
 
@@ -9,8 +12,8 @@ export function useVerifyCertification() {
   const { setEmailVerified } = useActions();
 
   return useMutation({
-    mutationFn: (variables: { localPart: string; code: string }) =>
-      verifyCertification(variables.localPart, variables.code),
+    mutationFn: (variables: CertificationVerifyRequest) =>
+      verifyCertification(variables),
     onSuccess: (data) => {
       setEmailVerified(Boolean(data?.isVerified));
       void queryClient.invalidateQueries({

--- a/src/libs/validation/zodSchemas.ts
+++ b/src/libs/validation/zodSchemas.ts
@@ -4,6 +4,9 @@ import { validationMessages as msg } from './messages';
 
 const trimmed = () => z.string().transform((value) => value.trim());
 
+const FLEXIBLE_URL_REGEX =
+  /^(?:(?:https?:\/\/)?(?:localhost(?::\d+)?|(?:[\w-]+\.)+[\w-]{2,}))(?:\S*)?$|^(?:blob:|data:)\S+$/i;
+
 export const nicknameSchema = trimmed()
   .min(1, { message: msg.required })
   .max(31, { message: msg.nickname.tooLong });
@@ -26,8 +29,8 @@ export const verifyCodeSchema = trimmed().regex(/^\d{6}$/, {
 });
 
 export const imageUrlSchema = trimmed()
-  .url({ message: msg.imageUrl.invalid })
-  .max(255, { message: msg.imageUrl.tooLong });
+  .max(255, { message: msg.imageUrl.tooLong })
+  .regex(FLEXIBLE_URL_REGEX, { message: msg.imageUrl.invalid });
 
 export const profileFormSchema = z.object({
   nickname: nicknameSchema,

--- a/src/mocks/handlers/certification.ts
+++ b/src/mocks/handlers/certification.ts
@@ -7,18 +7,24 @@ type CertificationResponse = { isVerified: boolean };
 
 type CertState = {
   localPart: string | null;
+  domain: string | null;
+  email: string | null;
   requested: boolean;
   isVerified: boolean;
 };
 
 const certState: CertState = {
   localPart: null,
+  domain: null,
+  email: null,
   requested: false,
   isVerified: false,
 };
 
 export const resetCertificationState = () => {
   certState.localPart = null;
+  certState.domain = null;
+  certState.email = null;
   certState.requested = false;
   certState.isVerified = false;
 };
@@ -26,6 +32,12 @@ export const resetCertificationState = () => {
 export const seedCertificationState = (state: Partial<CertState>) => {
   if (state.localPart !== undefined) {
     certState.localPart = state.localPart;
+  }
+  if (state.domain !== undefined) {
+    certState.domain = state.domain;
+  }
+  if (state.email !== undefined) {
+    certState.email = state.email;
   }
   if (state.requested !== undefined) {
     certState.requested = state.requested;
@@ -37,18 +49,38 @@ export const seedCertificationState = (state: Partial<CertState>) => {
 
 const requestEmail = http.post<
   never,
-  { localPart?: string },
+  { email?: string; localPart?: string; domain?: string },
   CertificationResponse | ApiErrorResponse
 >('*/api/v1/members/me/certification/email', async ({ request }) => {
-  const { localPart } = (await request.json()) as { localPart?: string };
+  const body = (await request.json()) as {
+    email?: string;
+    localPart?: string;
+    domain?: string;
+  };
 
-  if (!localPart || !localPart.trim())
-    return createErrorResponse('CERT_LOCAL_PART_REQUIRED');
-  if (localPart === 'limit') return createErrorResponse('CERT_RATE_LIMITED');
-  if (certState.isVerified && certState.localPart === localPart)
+  const rawEmail = body.email?.trim() ?? '';
+  const rawLocalPart = body.localPart?.trim() ?? '';
+  const rawDomain = body.domain?.trim() ?? '';
+  const derivedLocalPart =
+    rawLocalPart ||
+    (rawEmail.includes('@') ? rawEmail.split('@', 2)[0]?.trim() : '');
+  const derivedDomain =
+    rawDomain ||
+    (rawEmail.includes('@') ? rawEmail.split('@', 2)[1]?.trim() : '');
+  const normalizedEmail =
+    derivedLocalPart && derivedDomain
+      ? `${derivedLocalPart}@${derivedDomain}`
+      : rawEmail;
+
+  if (!derivedLocalPart) return createErrorResponse('CERT_LOCAL_PART_REQUIRED');
+  if (derivedLocalPart === 'limit')
+    return createErrorResponse('CERT_RATE_LIMITED');
+  if (certState.isVerified && certState.localPart === derivedLocalPart)
     return createErrorResponse('CERT_ALREADY_VERIFIED');
 
-  certState.localPart = localPart.trim();
+  certState.localPart = derivedLocalPart;
+  certState.domain = derivedDomain || null;
+  certState.email = normalizedEmail || null;
   certState.requested = true;
   certState.isVerified = false;
 
@@ -57,18 +89,34 @@ const requestEmail = http.post<
 
 const verifyEmail = http.post<
   never,
-  { localPart?: string; code?: string },
+  { email?: string; localPart?: string; domain?: string; code?: string },
   CertificationResponse | ApiErrorResponse
 >('*/api/v1/members/me/certification/verify', async ({ request }) => {
-  const { localPart, code } = (await request.json()) as {
+  const body = (await request.json()) as {
+    email?: string;
     localPart?: string;
+    domain?: string;
     code?: string;
   };
 
+  const rawEmail = body.email?.trim() ?? '';
+  const rawLocalPart = body.localPart?.trim() ?? '';
+  const rawDomain = body.domain?.trim() ?? '';
+  const derivedLocalPart =
+    rawLocalPart ||
+    (rawEmail.includes('@') ? rawEmail.split('@', 2)[0]?.trim() : '');
+  const derivedDomain =
+    rawDomain ||
+    (rawEmail.includes('@') ? rawEmail.split('@', 2)[1]?.trim() : '');
+  const code = body.code?.trim();
+
   if (!certState.requested || !certState.localPart)
     return createErrorResponse('CERT_NOT_REQUESTED');
-  if (!localPart || localPart.trim() !== certState.localPart)
+  if (!derivedLocalPart || derivedLocalPart !== certState.localPart)
     return createErrorResponse('CERT_NOT_REQUESTED');
+  if (certState.domain && derivedDomain && derivedDomain !== certState.domain) {
+    return createErrorResponse('CERT_NOT_REQUESTED');
+  }
   if (code !== '000000') return createErrorResponse('CERT_INVALID_TOKEN');
 
   certState.isVerified = true;

--- a/src/tests/mocks/mswHandlers.test.ts
+++ b/src/tests/mocks/mswHandlers.test.ts
@@ -122,14 +122,17 @@ describe('Certification 핸들러', () => {
   it('요청 → 검증(실패) → 검증(성공) → 상태', async () => {
     const req = await requestJson<CertificationResponse>(
       '/api/v1/members/me/certification/email',
-      { method: 'POST', body: { localPart: 'user' } },
+      { method: 'POST', body: { email: 'user@pusan.ac.kr' } },
     );
     expect(req.status).toBe(200);
     expect(req.data.isVerified).toBe(false);
 
     const bad = await requestJson<ApiErrorResponse>(
       '/api/v1/members/me/certification/verify',
-      { method: 'POST', body: { localPart: 'user', code: '123456' } },
+      {
+        method: 'POST',
+        body: { email: 'user@pusan.ac.kr', code: '123456' },
+      },
     );
     expect(bad.status).toBe(400);
     expect(bad.data.error).toEqual({
@@ -139,7 +142,10 @@ describe('Certification 핸들러', () => {
 
     const ok = await requestJson<CertificationResponse>(
       '/api/v1/members/me/certification/verify',
-      { method: 'POST', body: { localPart: 'user', code: '000000' } },
+      {
+        method: 'POST',
+        body: { email: 'user@pusan.ac.kr', code: '000000' },
+      },
     );
     expect(ok.status).toBe(200);
     expect(ok.data.isVerified).toBe(true);

--- a/src/tests/validation/zodSchemas.test.ts
+++ b/src/tests/validation/zodSchemas.test.ts
@@ -14,6 +14,17 @@ describe('profileFormSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('스킴이 없는 이미지 주소도 허용', () => {
+    const result = profileFormSchema.safeParse({
+      nickname: '홍길동',
+      description: '',
+      email: 'hong@example.com',
+      imageUrl: 'cdn.example.com/avatar.png',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it('잘못된 이메일은 실패', () => {
     const result = profileFormSchema.safeParse({
       nickname: '홍길동',
@@ -26,6 +37,22 @@ describe('profileFormSchema', () => {
     if (!result.success) {
       expect(result.error.issues[0]?.message).toBe(
         '유효한 이메일 주소가 아닙니다.',
+      );
+    }
+  });
+
+  it('유효하지 않은 이미지 주소는 실패', () => {
+    const result = profileFormSchema.safeParse({
+      nickname: '홍길동',
+      description: '소개',
+      email: 'hong@example.com',
+      imageUrl: 'not a valid url',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        '올바른 이미지 URL이 아닙니다.',
       );
     }
   });


### PR DESCRIPTION
## Summary
- add clickable/suffix support to the shared TextField component to enable profile email interactions and inline clear actions
- refresh profile edit and email certification flows with flexible URL validation, preview syncing, and enhanced API handling including conflict states
- harden routing/session guards and expand test coverage for the updated profile, certification, and validation behaviours

## Testing
- npm run lint
- npx vitest run src/tests/ui/profileEdit.a11y.test.tsx
- npx vitest run src/tests/validation/zodSchemas.test.ts


------
https://chatgpt.com/codex/tasks/task_e_690ca6f42ecc833289a87e21b4b2cb69