### PR TITLE
feat: require school selection before email verification

### DIFF
--- a/src/api/schools.ts
+++ b/src/api/schools.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '@/api/core/axiosInstance';
+
+export type SchoolResponse = {
+  id: number;
+  name: string;
+  domain: string;
+};
+
+export async function selectSchool(schoolId: number) {
+  const { data } = await apiClient.post<SchoolResponse>(
+    `/api/v1/members/me/school/${schoolId}`,
+  );
+
+  return data;
+}

--- a/src/pages/EmailCert/EmailCertPage.styled.ts
+++ b/src/pages/EmailCert/EmailCertPage.styled.ts
@@ -70,6 +70,12 @@ export const Input = styled.input`
     outline: 3px solid rgba(33, 124, 249, 0.35);
     outline-offset: 2px;
   }
+
+  &:disabled {
+    background: ${({ theme }) => theme.gray[100]};
+    color: ${({ theme }) => theme.text.placeholder};
+    cursor: not-allowed;
+  }
 `;
 
 export const Hint = styled.p`
@@ -106,6 +112,32 @@ export const Primary = styled.button`
 export const Secondary = styled(Primary)`
   background: ${({ theme }) => theme.gray[200]};
   color: ${({ theme }) => theme.text.default};
+`;
+
+export const SchoolButton = styled.button<{ selected: boolean }>`
+  flex: 1;
+  padding: ${({ theme }) => `${theme.spacing2} ${theme.spacing3}`};
+  border-radius: 12px;
+  border: 1px solid
+    ${({ theme, selected }) =>
+      selected ? theme.blue[700] : theme.border.default};
+  background: ${({ theme, selected }) =>
+    selected ? theme.blue[700] : theme.gray[100]};
+  color: ${({ theme, selected }) =>
+    selected ? theme.gray[0] : theme.text.sub};
+  font-size: ${({ theme }) => theme.body1Bold.fontSize};
+  font-weight: ${({ theme }) => theme.body1Bold.fontWeight};
+  line-height: ${({ theme }) => theme.body1Bold.lineHeight};
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease,
+    border 0.2s ease;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
 `;
 
 export const Notice = styled.p`

--- a/src/tests/certification/EmailCertPage.test.tsx
+++ b/src/tests/certification/EmailCertPage.test.tsx
@@ -84,12 +84,22 @@ afterEach(() => {
 });
 
 describe('EmailCertPage', () => {
+  const selectBusanUniversity = async () => {
+    fireEvent.click(screen.getByRole('button', { name: '부산대학교' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('학교 이메일 주소')).not.toBeDisabled();
+    });
+  };
+
   it('이메일 전송 후 쿨다운 시간을 표시한다', async () => {
     renderEmailCertPage();
 
     await waitFor(() => {
       expect(screen.getByLabelText('email-cert-page')).toBeInTheDocument();
     });
+
+    await selectBusanUniversity();
 
     fireEvent.change(screen.getByLabelText('학교 이메일 주소'), {
       target: { value: 'user@pusan.ac.kr' },
@@ -107,6 +117,8 @@ describe('EmailCertPage', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('email-cert-page')).toBeInTheDocument();
     });
+
+    await selectBusanUniversity();
 
     fireEvent.change(screen.getByLabelText('학교 이메일 주소'), {
       target: { value: 'user' },
@@ -129,6 +141,8 @@ describe('EmailCertPage', () => {
       expect(screen.getByLabelText('email-cert-page')).toBeInTheDocument();
     });
 
+    await selectBusanUniversity();
+
     fireEvent.change(screen.getByLabelText('학교 이메일 주소'), {
       target: { value: 'limit@pusan.ac.kr' },
     });
@@ -145,6 +159,8 @@ describe('EmailCertPage', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('email-cert-page')).toBeInTheDocument();
     });
+
+    await selectBusanUniversity();
 
     fireEvent.change(screen.getByLabelText('학교 이메일 주소'), {
       target: { value: 'user@pusan.ac.kr' },
@@ -173,6 +189,8 @@ describe('EmailCertPage', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('email-cert-page')).toBeInTheDocument();
     });
+
+    await selectBusanUniversity();
 
     fireEvent.click(screen.getByRole('button', { name: 'email-cert-go-back' }));
 
@@ -213,6 +231,8 @@ describe('EmailCertPage', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('email-cert-page')).toBeInTheDocument();
     });
+
+    await selectBusanUniversity();
 
     fireEvent.change(screen.getByLabelText('학교 이메일 주소'), {
       target: { value: 'user@pusan.ac.kr' },

--- a/src/tests/routing/routeGuards.test.tsx
+++ b/src/tests/routing/routeGuards.test.tsx
@@ -139,6 +139,12 @@ describe('Route Guards', () => {
       expect(screen.getByLabelText('email-cert-page')).toBeInTheDocument();
     });
 
+    fireEvent.click(screen.getByRole('button', { name: '부산대학교' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('학교 이메일 주소')).not.toBeDisabled();
+    });
+
     fireEvent.change(screen.getByLabelText('학교 이메일 주소'), {
       target: { value: 'user@pusan.ac.kr' },
     });


### PR DESCRIPTION
## Summary
- add the selectSchool API to register a user’s school prior to email verification
- require users to choose Busan National University before entering an email and disable certification controls until selection is complete
- refresh related styles and tests to cover the new school-selection flow

## Testing
- pnpm lint
- pnpm vitest run src/tests/certification/EmailCertPage.test.tsx src/tests/routing/routeGuards.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_690ce0d3fb0c8332bb587489a626c6de