### PR TITLE
feat: refresh home match card styling

### DIFF
--- a/src/components/matchCard/matchCardLayout.styled.ts
+++ b/src/components/matchCard/matchCardLayout.styled.ts
@@ -1,361 +1,291 @@
+import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
-import { MdAccessTime, MdPeople, MdLocationOn } from 'react-icons/md';
 
-import { colors } from '@/theme/color';
-import { spacing } from '@/theme/spacing';
-import { typography } from '@/theme/typography';
-
-/**
- * 매치카드 전체 컨테이너
- */
-export const LayoutContainer = styled.div`
-  /* 배경색 - 카드 전체 배경 */
-  background: ${colors.background.default};
-
-  /* 모서리 둥글기 - 카드 테두리 둥근 정도 */
-  border-radius: 0px;
-  border: 1px solid ${colors.gray[300]};
-
-  /* 카드 크기 - 상위 컨테이너 크기에 비례 */
-  width: 100%; /* 카드 너비 */
-  height: 80px; /* 카드 높이 */
-
-  /* 레이아웃 기본 설정 */
-  position: relative;
-  display: flex;
-  align-items: center; /* 세로 정렬 */
-
-  /* 그림자 효과 - 카드 입체감 */
-  box-shadow: 0 0px 0px rgba(0, 0, 0, 0.1); /* 기본 그림자 */
-
-  /* 인터랙션 효과 */
-  cursor: pointer;
-  transition: box-shadow 0.2s ease; /* 애니메이션 속도 */
-
-  /* 호버 시 그림자 효과 강화 */
-  &:hover {
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15); /* 호버 그림자 */
+const scaleIn = keyframes`
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
   }
 `;
 
-/**
- * 왼쪽 이미지 영역
- */
+const shimmer = keyframes`
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+`;
+
+export const LayoutContainer = styled.div`
+  display: flex;
+  gap: 16px;
+  padding: 20px;
+  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
+  border-radius: 20px;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  cursor: pointer;
+  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+  animation: ${scaleIn} 0.4s ease-out;
+  box-shadow:
+    0 2px 12px rgba(15, 23, 42, 0.06),
+    0 1px 3px rgba(15, 23, 42, 0.04);
+  --card-title-color: #0f172a;
+  --card-info-color: #64748b;
+  --image-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+  --image-scale: 1;
+  --badge-translate: 0px;
+  --badge-primary-shadow: 0 2px 8px rgba(59, 130, 246, 0.2);
+  --badge-warning-shadow: 0 2px 8px rgba(245, 158, 11, 0.2);
+  --badge-success-shadow: 0 2px 8px rgba(16, 185, 129, 0.2);
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, #3b82f6 0%, #8b5cf6 50%, #ec4899 100%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 50%;
+    height: 100%;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      rgba(255, 255, 255, 0.4) 50%,
+      transparent 100%
+    );
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
+
+  &:hover {
+    transform: translateY(-6px) scale(1.01);
+    border-color: rgba(59, 130, 246, 0.3);
+    box-shadow:
+      0 12px 32px rgba(15, 23, 42, 0.12),
+      0 8px 24px rgba(59, 130, 246, 0.15);
+    background: linear-gradient(135deg, #ffffff 0%, #eff6ff 100%);
+    --card-title-color: #1e40af;
+    --card-info-color: #475569;
+    --image-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+    --image-scale: 1.08;
+    --badge-translate: -2px;
+    --badge-primary-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+    --badge-warning-shadow: 0 4px 12px rgba(245, 158, 11, 0.3);
+    --badge-success-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
+
+    &::before {
+      opacity: 1;
+    }
+  }
+
+  &:hover::after {
+    opacity: 1;
+    animation: ${shimmer} 1.5s ease-in-out infinite;
+  }
+
+  &:active {
+    transform: translateY(-3px) scale(0.99);
+    transition: all 0.1s ease;
+  }
+`;
+
 export const LeftSlot = styled.div`
-  /* 이미지 영역 크기 */
-  width: 60px; /* 이미지 너비 */
-  height: 60px; /* 이미지 높이 */
-
-  /* 이미지 여백 - 카드 내에서의 위치 */
-  margin: 10px; /* 이미지 주변 여백 */
-
-  /* 크기 고정 설정 */
+  position: relative;
+  width: 120px;
+  height: 120px;
   flex-shrink: 0;
-`;
-
-/**
- * 실제 이미지 스타일
- */
-export const SlotImage = styled.img`
-  /* 이미지 크기 - 부모 영역에 맞춤 */
-  width: 100%;
-  height: 100%;
-
-  /* 이미지 모서리 둥글기 */
-  border-radius: 0px; /* 이미지 둥근 정도 */
-
-  /* 이미지 크롭 방식 */
-  object-fit: cover; /* 이미지 자르기 방식 */
-`;
-
-/**
- * 이미지 플레이스홀더
- */
-export const ImagePlaceholder = styled.div`
-  /* 플레이스홀더 크기 */
-  width: 100%;
-  height: 100%;
-
-  /* 플레이스홀더 모서리 */
-  border-radius: 0px; /* 모서리 둥근 정도 */
-
-  /* 플레이스홀더 배경색 */
-  background: ${colors.gray[200]}; /* 배경색 */
-
-  /* 아이콘 중앙 정렬 */
+  border-radius: 16px;
+  overflow: hidden;
+  background: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%);
+  box-shadow: var(--image-shadow);
   display: flex;
   align-items: center;
   justify-content: center;
-
-  /* 아이콘 기본 색상 */
-  color: ${colors.gray[500]}; /* 아이콘 색상 */
-
-  /* 플레이스홀더 테두리 */
-  border: 1px solid ${colors.gray[300]};
+  z-index: 1;
 `;
 
-/**
- * 플레이스홀더 위치 아이콘
- */
-export const PlaceholderLocationIcon = styled(MdLocationOn)`
-  /* 아이콘 크기 */
-  width: 30px; /* 아이콘 너비 */
-  height: 30px; /* 아이콘 높이 */
-
-  /* 아이콘 색상 */
-  color: ${colors.gray[500]}; /* 아이콘 색상 */
+export const SlotImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  transform: scale(var(--image-scale));
 `;
 
-/**
- * 가운데 텍스트 영역
- */
-export const CenterSlot = styled.div`
-  /* 영역 확장 설정 - 남은 공간을 모두 차지 */
-  flex: 1;
-
-  /* Flutter의 MainAxisAlignment.spaceEvenly와 동일한 효과 */
+export const ImagePlaceholder = styled.div`
+  width: 100%;
+  height: 100%;
   display: flex;
-  flex-direction: column; /* 세로 방향 배치 */
+  align-items: center;
   justify-content: center;
+  background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
+  font-size: 48px;
+  color: rgba(15, 23, 42, 0.35);
+`;
+
+export const CenterSlot = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
   gap: 8px;
-
-  /* 텍스트 오버플로우 방지 */
   min-width: 0;
+  position: relative;
+  z-index: 1;
 `;
 
-/**
- * 장소명 제목 스타일
- */
-export const InfoTitle = styled.span`
-  display: block; /* 블록 요소처럼 동작 */
-
-  /* 제목 폰트 크기 */
-  font-size: 12px; /* 제목 크기 */
-  font-weight: 400; /* 제목 굵기 */
-  line-height: 15px; /* 제목 줄 높이 */
-
-  /* 제목 폰트 스타일 */
-  ${typography.subtitle2Bold};
-  color: ${colors.text.default};
-
-  /* 제목 폰트 패밀리 */
-  font-family: 'Inter-Regular', sans-serif; /* 제목 폰트 */
-
-  /* 긴 텍스트 처리 */
+export const InfoTitle = styled.h3`
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--card-title-color);
+  letter-spacing: -0.01em;
   overflow: hidden;
-  text-overflow: ellipsis; /* 긴 텍스트 ... 표시 */
-  white-space: nowrap; /* 텍스트 한 줄로 제한 */
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: color 0.3s ease;
 `;
 
-/**
- * 시간 정보 컨테이너
- */
-export const InfoTime = styled.div`
-  /* 시간 정보 레이아웃 */
+export const InfoRow = styled.div`
   display: flex;
-  align-items: center; /* 아이콘과 텍스트 세로 정렬 */
-  gap: 2px; /* 아이콘과 텍스트 간격 */
-
-  /* 시간 텍스트 색상 */
-  color: ${colors.text.default}; /* 시간 텍스트 색상 */
-
-  /* 시간 폰트 스타일 */
-  font-size: 12px; /* 시간 폰트 크기 */
-  font-weight: 400; /* 시간 폰트 굵기 */
-  line-height: 15px; /* 시간 줄 높이 */
-  font-family: 'Inter-Regular', sans-serif; /* 시간 폰트 */
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--card-info-color);
+  font-weight: 500;
+  transition: color 0.3s ease;
 `;
 
-/**
- * 시간 아이콘 스타일
- */
-export const TimeIcon = styled(MdAccessTime)`
-  /* 시계 아이콘 색상 */
-  color: ${colors.red[700]}; /* 시계 아이콘 색상 */
-
-  /* 시계 아이콘 크기 */
-  font-size: 15px; /* 시계 아이콘 크기 */
+export const Icon = styled.span`
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
 `;
 
-/**
- * 오른쪽 액션 영역
- */
 export const RightSlot = styled.div`
-  /* 버튼 영역 여백 */
-  padding: 10px; /* 버튼 주변 여백 */
-
-  /* 크기 고정 - 내용에 맞게 크기 유지 */
-  flex-shrink: 0;
-
-  /* 정렬 설정 */
   display: flex;
-  align-items: center; /* 세로 정렬 */
-  justify-content: flex-end; /* 가로 정렬 */
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 8px;
+  margin-left: auto;
+  min-width: max-content;
+  position: relative;
+  z-index: 1;
 `;
 
-/* ===== 인원 정보 관련 스타일 ===== */
-
-/**
- * 인원 정보 전체 컨테이너
- */
-export const PeopleInfoContainer = styled.div`
-  /* 인원 정보 레이아웃 */
+export const BadgeContainer = styled.div`
   display: flex;
-  flex-direction: column; /* 세로 배치 */
-  align-items: flex-end; /* 오른쪽 정렬 */
-  gap: 8px; /* 인원수와 마감일 사이 간격 */
+  align-items: center;
+  gap: 8px;
+  margin-top: auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 `;
 
-/**
- * 인원 수 정보 스타일
- */
-export const PeopleCount = styled.div`
-  /* 인원 정보 레이아웃 */
-  display: flex;
-  align-items: center; /* 아이콘과 숫자 세로 정렬 */
-  gap: 4px; /* 아이콘과 숫자 간격 */
-
-  /* 인원 텍스트 색상 */
-  color: ${colors.text.default}; /* 인원 텍스트 색상 */
-
-  /* 인원 폰트 스타일 */
-  font-size: 12px; /* 인원 폰트 크기 */
-  font-weight: 400; /* 인원 폰트 굵기 */
-  font-family: 'Inter-Regular', sans-serif; /* 인원 폰트 */
-
-  /* 텍스트 정렬 */
-  text-align: right; /* 인원 텍스트 정렬 */
-`;
-
-/**
- * 인원 아이콘 스타일
- */
-export const PeopleIcon = styled(MdPeople)`
-  /* 인원 아이콘 색상 */
-  color: ${colors.yellow[600]}; /* 인원 아이콘 색상 */
-
-  /* 인원 아이콘 크기 */
-  font-size: 15px; /* 인원 아이콘 크기 */
-`;
-
-/**
- * 마감일 정보 스타일
- */
-export const Deadline = styled.div`
-  /* 마감일 텍스트 색상 */
-  color: ${colors.text.default}; /* 마감일 색상 */
-
-  /* 마감일 폰트 스타일 */
-  font-size: 12px; /* 마감일 폰트 크기 */
-  font-weight: 400; /* 마감일 폰트 굵기 */
-  font-family: 'Inter-Regular', sans-serif; /* 마감일 폰트 */
-
-  /* 마감일 텍스트 정렬 */
-  text-align: right; /* 마감일 정렬 */
-`;
-
-/* ===== 액션 버튼 관련 스타일 ===== */
-
-/**
- * 취소하기 버튼 스타일
- */
-export const CancelButton = styled.button`
-  /* 버튼 크기 */
-  padding: ${spacing.spacing2} ${spacing.spacing4}; /* 버튼 안쪽 여백 */
-
-  /* 버튼 모양 */
-  border-radius: 20px; /* 버튼 모서리 둥근 정도 */
-  border: 1px solid ${colors.red[500]}; /* 버튼 테두리 색상 */
-  background: ${colors.background.default}; /* 버튼 배경색 */
-
-  /* 버튼 텍스트 색상 */
-  color: ${colors.red[700]}; /* 버튼 텍스트 색상 */
-
-  /* 버튼 폰트 */
-  font-size: ${typography.body2Regular.fontSize}; /* 버튼 폰트 크기 */
-  font-weight: ${typography.body2Bold.fontWeight}; /* 버튼 폰트 굵기 */
-
-  /* 버튼 기본 설정 */
-  cursor: pointer;
-  transition: all 0.2s ease; /* 버튼 애니메이션 속도 */
-  white-space: nowrap; /* 버튼 텍스트 줄바꿈 방지 */
-
-  /* 버튼 호버 효과 */
-  &:hover {
-    background: ${colors.red[100]}; /* 호버시 배경색 */
-  }
-
-  /* 버튼 클릭 효과 */
-  &:active {
-    background: ${colors.red[200]}; /* 클릭시 배경색 */
-  }
-
-  /* 버튼 비활성화 효과 */
-  &:disabled {
-    opacity: 0.5; /* 비활성화시 투명도 */
-    cursor: not-allowed;
-  }
-`;
-
-/**
- * 결과 보기 버튼 스타일
- */
-export const ResultButton = styled.button`
-  /* 버튼 크기 */
-  padding: ${spacing.spacing2} ${spacing.spacing4}; /* 버튼 안쪽 여백 */
-
-  /* 버튼 모양 */
-  border-radius: 20px; /* 버튼 모서리 둥근 정도 */
-  border: 1px solid ${colors.blue[700]}; /* 버튼 테두리 색상 */
-  background: ${colors.background.default}; /* 버튼 배경색 */
-
-  /* 버튼 텍스트 색상 */
-  color: ${colors.blue[700]}; /* 버튼 텍스트 색상 */
-
-  /* 버튼 폰트 */
-  font-size: ${typography.body2Regular.fontSize}; /* 버튼 폰트 크기 */
-  font-weight: ${typography.body2Bold.fontWeight}; /* 버튼 폰트 굵기 */
-
-  /* 버튼 기본 설정 */
-  cursor: pointer;
-  transition: all 0.2s ease; /* 버튼 애니메이션 속도 */
-  white-space: nowrap; /* 버튼 텍스트 줄바꿈 방지 */
-
-  /* 버튼 호버 효과 */
-  &:hover {
-    background: ${colors.blue[100]}; /* 호버시 배경색 */
-  }
-
-  /* 버튼 클릭 효과 */
-  &:active {
-    background: ${colors.blue[200]}; /* 클릭시 배경색 */
-  }
-
-  /* 버튼 비활성화 효과 */
-  &:disabled {
-    opacity: 0.5; /* 비활성화시 투명도 */
-    cursor: not-allowed;
-  }
-`;
-
-/**
- * 완료된 매치카드 컨테이너
- */
-export const FinishedCardContainer = styled(LayoutContainer)`
-  /* 완료된 카드 전체 투명도 효과 */
-  opacity: 0.6;
-
-  /* 완료된 카드 이미지 블러 효과 - 클래스 셀렉터 사용 */
-  .left-slot {
-    filter: blur(1px);
-  }
-
-  /* 호버 시 약간 더 선명하게 */
-  &:hover {
-    opacity: 0.8;
-
-    .left-slot {
-      filter: blur(0.5px);
+export const Badge = styled.span<{
+  variant?: 'primary' | 'warning' | 'success';
+}>`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  transition: all 0.3s ease;
+  transform: translateY(var(--badge-translate));
+  color: ${({ variant = 'primary' }) => {
+    switch (variant) {
+      case 'warning':
+        return '#78350F';
+      case 'success':
+        return '#065F46';
+      default:
+        return '#1E40AF';
     }
+  }};
+  background: ${({ variant = 'primary' }) => {
+    switch (variant) {
+      case 'warning':
+        return 'linear-gradient(135deg, #FEF3C7 0%, #FDE68A 100%)';
+      case 'success':
+        return 'linear-gradient(135deg, #D1FAE5 0%, #A7F3D0 100%)';
+      default:
+        return 'linear-gradient(135deg, #DBEAFE 0%, #BFDBFE 100%)';
+    }
+  }};
+  box-shadow: ${({ variant = 'primary' }) => `var(--badge-${variant}-shadow)`};
+`;
+
+export const ActionButton = styled.button<{ variant: 'cancel' | 'result' }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 18px;
+  border-radius: 14px;
+  border: none;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: #ffffff;
+  cursor: pointer;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: ${({ variant }) =>
+    variant === 'cancel'
+      ? '0 2px 10px rgba(248, 113, 113, 0.35)'
+      : '0 2px 10px rgba(59, 130, 246, 0.35)'};
+  background: ${({ variant }) =>
+    variant === 'cancel'
+      ? 'linear-gradient(135deg, #FCA5A5 0%, #F87171 100%)'
+      : 'linear-gradient(135deg, #93C5FD 0%, #3B82F6 100%)'};
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: ${({ variant }) =>
+      variant === 'cancel'
+        ? '0 6px 16px rgba(248, 113, 113, 0.45)'
+        : '0 6px 16px rgba(59, 130, 246, 0.45)'};
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+  }
+`;
+
+export const FinishedCardContainer = styled(LayoutContainer)`
+  opacity: 0.85;
+  filter: grayscale(0.15);
+
+  &:hover {
+    opacity: 0.95;
+    filter: grayscale(0);
   }
 `;

--- a/src/components/matchCard/matchCardSlots.tsx
+++ b/src/components/matchCard/matchCardSlots.tsx
@@ -8,11 +8,6 @@ import type {
   ActionSlotProps,
 } from './matchCardLayout.types';
 
-/**
- * 이미지 슬롯 컴포넌트
- * - 매치 장소의 이미지를 표시하거나 이미지가 없을 때 플레이스홀더를 표시
- * - matchCard, recruitingMatchCard, setMatchCard, finishedMatchCard 공통으로 사용
- */
 export const ImageSlot: React.FC<ImageSlotProps> = ({
   src,
   alt = '매치 장소',
@@ -23,80 +18,63 @@ export const ImageSlot: React.FC<ImageSlotProps> = ({
       {src ? (
         <S.SlotImage src={src} alt={alt} />
       ) : (
-        <S.ImagePlaceholder>
-          {placeholder || <S.PlaceholderLocationIcon />}
-        </S.ImagePlaceholder>
+        <S.ImagePlaceholder>{placeholder ?? '🏀'}</S.ImagePlaceholder>
       )}
     </>
   );
 };
 
-/**
- * 정보 슬롯 컴포넌트
- * - 장소명과 시간 정보를 세로로 배치하여 표시
- * - 모든 매치카드 변형에서 공통으로 사용되는 핵심 정보
- */
 export const InfoSlot: React.FC<InfoSlotProps> = ({ title, time }) => {
   return (
     <>
-      <S.InfoTitle>장소: {title}</S.InfoTitle>
-      <S.InfoTime>
-        <S.TimeIcon />
-        <span>시간: {time}</span>
-      </S.InfoTime>
+      <S.InfoTitle>{title}</S.InfoTitle>
+      <S.InfoRow>
+        <S.Icon aria-hidden="true">🕒</S.Icon>
+        <span>{time}</span>
+      </S.InfoRow>
     </>
   );
 };
 
-/**
- * 인원 정보 슬롯 컴포넌트
- * - recruitingMatchCard에서만 사용
- * - 제한 인원과 지원 마감일을 우측 정렬로 표시
- */
 export const PeopleInfoSlot: React.FC<PeopleInfoSlotProps> = ({
   peopleCount,
   deadline,
 }) => {
   return (
-    <S.PeopleInfoContainer>
-      <S.PeopleCount>
-        <S.PeopleIcon />
-        <span>제한 인원 : {peopleCount}</span>
-      </S.PeopleCount>
-      {deadline && <S.Deadline>지원 마감 : {deadline}</S.Deadline>}
-    </S.PeopleInfoContainer>
+    <S.BadgeContainer>
+      <S.Badge>
+        <S.Icon aria-hidden="true">👥</S.Icon>
+        <span>모집 {peopleCount}</span>
+      </S.Badge>
+      {deadline && (
+        <S.Badge variant="warning">
+          <S.Icon aria-hidden="true">⏳</S.Icon>
+          <span>마감 {deadline}</span>
+        </S.Badge>
+      )}
+    </S.BadgeContainer>
   );
 };
 
-/**
- * 액션 버튼 슬롯 컴포넌트
- * - setMatchCard의 '취소하기' 버튼과 finishedMatchCard의 '결과 보기' 버튼에 사용
- * - variant에 따라 다른 스타일이 적용됨
- */
 export const ActionSlot: React.FC<ActionSlotProps> = ({
   text,
   variant = 'cancel',
   onClick,
   disabled = false,
 }) => {
-  // 이벤트 버블링 방지 핸들러
   const handleClick = (e: React.MouseEvent) => {
-    e.stopPropagation(); // 카드 클릭 이벤트와 분리
+    e.stopPropagation();
     onClick(e);
   };
 
-  if (variant === 'result') {
-    return (
-      <S.ResultButton onClick={handleClick} disabled={disabled}>
-        {text}
-      </S.ResultButton>
-    );
-  }
-
-  // 기본값은 'cancel' 스타일
   return (
-    <S.CancelButton onClick={handleClick} disabled={disabled}>
+    <S.ActionButton
+      variant={variant}
+      onClick={handleClick}
+      disabled={disabled}
+      type="button"
+    >
       {text}
-    </S.CancelButton>
+    </S.ActionButton>
   );
 };

--- a/src/pages/Home/HomePage.styled.ts
+++ b/src/pages/Home/HomePage.styled.ts
@@ -240,17 +240,13 @@ export const MatchListContainer = styled.div`
 /**
  * 매치 카드 아이템
  */
-export const MatchCardItem = styled.div`
+export const MatchCardItem = styled.div<{ index?: number }>`
   margin-bottom: ${spacing.spacing4};
   animation: ${fadeIn} 0.5s ease-out backwards;
-  animation-delay: calc(var(--index, 0) * 0.05s);
+  animation-delay: ${({ index }) => (index ? `${index * 0.05}s` : '0s')};
 
   &:last-child {
     margin-bottom: 0;
-  }
-
-  &:hover {
-    animation: ${float} 2s ease-in-out infinite;
   }
 `;
 

--- a/src/tests/component/matchCard/matchCard.test.tsx
+++ b/src/tests/component/matchCard/matchCard.test.tsx
@@ -28,10 +28,8 @@ describe('MatchCard Preset 컴포넌트들', () => {
 
       renderWithTheme(<BasicMatchCard title={testTitle} time={testTime} />);
 
-      // "장소: " 접두사와 함께 title이 표시되는지 확인
-      expect(screen.getByText(`장소: ${testTitle}`)).toBeInTheDocument();
-      // "시간: " 접두사와 함께 time이 표시되는지 확인
-      expect(screen.getByText(`시간: ${testTime}`)).toBeInTheDocument();
+      expect(screen.getByText(testTitle)).toBeInTheDocument();
+      expect(screen.getByText(testTime)).toBeInTheDocument();
     });
 
     it('이미지가 제공되면 올바르게 표시된다', () => {
@@ -56,15 +54,9 @@ describe('MatchCard Preset 컴포넌트들', () => {
         <BasicMatchCard title={defaultProps.title} time={defaultProps.time} />,
       );
 
-      // 이미지 요소가 없는지 확인
       expect(screen.queryByRole('img')).not.toBeInTheDocument();
-      // 기본 정보는 표시되는지 확인
-      expect(
-        screen.getByText(`장소: ${defaultProps.title}`),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(`시간: ${defaultProps.time}`),
-      ).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.time)).toBeInTheDocument();
     });
   });
 
@@ -82,12 +74,8 @@ describe('MatchCard Preset 컴포넌트들', () => {
         />,
       );
 
-      expect(
-        screen.getByText(`제한 인원 : ${testPeopleCount}`),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(`지원 마감 : ${testDeadline}`),
-      ).toBeInTheDocument();
+      expect(screen.getByText(`모집 ${testPeopleCount}`)).toBeInTheDocument();
+      expect(screen.getByText(`마감 ${testDeadline}`)).toBeInTheDocument();
     });
 
     it('deadline이 없어도 peopleCount는 표시된다', () => {
@@ -101,10 +89,8 @@ describe('MatchCard Preset 컴포넌트들', () => {
         />,
       );
 
-      expect(
-        screen.getByText(`제한 인원 : ${testPeopleCount}`),
-      ).toBeInTheDocument();
-      expect(screen.queryByText(/지원 마감/)).not.toBeInTheDocument();
+      expect(screen.getByText(`모집 ${testPeopleCount}`)).toBeInTheDocument();
+      expect(screen.queryByText(/마감/)).not.toBeInTheDocument();
     });
 
     it('기본 정보도 함께 표시된다', () => {
@@ -116,12 +102,8 @@ describe('MatchCard Preset 컴포넌트들', () => {
         />,
       );
 
-      expect(
-        screen.getByText(`장소: ${defaultProps.title}`),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(`시간: ${defaultProps.time}`),
-      ).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.time)).toBeInTheDocument();
     });
   });
 
@@ -152,12 +134,8 @@ describe('MatchCard Preset 컴포넌트들', () => {
         />,
       );
 
-      expect(
-        screen.getByText(`장소: ${defaultProps.title}`),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(`시간: ${defaultProps.time}`),
-      ).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.time)).toBeInTheDocument();
       expect(screen.getByText('취소하기')).toBeInTheDocument();
       expect(screen.getByAltText(defaultProps.title)).toHaveAttribute(
         'src',
@@ -193,12 +171,8 @@ describe('MatchCard Preset 컴포넌트들', () => {
         />,
       );
 
-      expect(
-        screen.getByText(`장소: ${defaultProps.title}`),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(`시간: ${defaultProps.time}`),
-      ).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.time)).toBeInTheDocument();
       expect(screen.getByText('결과 보기')).toBeInTheDocument();
       expect(screen.getByAltText(defaultProps.title)).toHaveAttribute(
         'src',
@@ -211,14 +185,12 @@ describe('MatchCard Preset 컴포넌트들', () => {
     it('모든 컴포넌트가 기본 구조를 가진다', () => {
       const mockFn = () => {};
 
-      // BasicMatchCard
       const { rerender } = renderWithTheme(
         <BasicMatchCard title={defaultProps.title} time={defaultProps.time} />,
       );
-      expect(screen.getByText(/장소:/)).toBeInTheDocument();
-      expect(screen.getByText(/시간:/)).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.time)).toBeInTheDocument();
 
-      // RecruitingMatchCard
       rerender(
         <ThemeProvider theme={theme}>
           <RecruitingMatchCard
@@ -228,10 +200,9 @@ describe('MatchCard Preset 컴포넌트들', () => {
           />
         </ThemeProvider>,
       );
-      expect(screen.getByText(/장소:/)).toBeInTheDocument();
-      expect(screen.getByText(/시간:/)).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.time)).toBeInTheDocument();
 
-      // SetMatchCard
       rerender(
         <ThemeProvider theme={theme}>
           <SetMatchCard
@@ -241,10 +212,9 @@ describe('MatchCard Preset 컴포넌트들', () => {
           />
         </ThemeProvider>,
       );
-      expect(screen.getByText(/장소:/)).toBeInTheDocument();
-      expect(screen.getByText(/시간:/)).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.time)).toBeInTheDocument();
 
-      // FinishedMatchCard
       rerender(
         <ThemeProvider theme={theme}>
           <FinishedMatchCard
@@ -254,8 +224,8 @@ describe('MatchCard Preset 컴포넌트들', () => {
           />
         </ThemeProvider>,
       );
-      expect(screen.getByText(/장소:/)).toBeInTheDocument();
-      expect(screen.getByText(/시간:/)).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.time)).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- restyle the match card container with animated gradients, hover shimmer, and badge styling updates
- adjust match card slot components and home page list animation to match the new design language
- update match card tests to reflect the revised copy and structure

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_690d02e33fbc8332a7d875517a8bf6df