### PR TITLE
style: refresh login experience visuals

### DIFF
--- a/src/components/dropDown/dropDown.styled.ts
+++ b/src/components/dropDown/dropDown.styled.ts
@@ -1,9 +1,27 @@
-/**
- * DropDown 컴포넌트들의 Emotion 스타일 정의
- */
-
-import { css } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
+
+const slideDown = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(-12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const scaleIn = keyframes`
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+`;
 
 /**
  * 전체 드롭다운 컨테이너
@@ -12,6 +30,7 @@ export const DropDownContainer = styled.div`
   position: relative;
   width: 100%;
   max-width: 360px;
+  animation: ${scaleIn} 0.3s ease-out;
 `;
 
 /**
@@ -22,29 +41,79 @@ export const DropDownHeader = styled.button`
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  padding: 12px 16px;
-  background-color: white;
-  border: 1px solid #d1d5db;
-  border-radius: 8px;
+  padding: 14px 18px;
+  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
+  border: 2px solid rgba(226, 232, 240, 0.8);
+  border-radius: 16px;
   cursor: pointer;
-  font-size: 16px;
-  color: #111827;
-  transition: all 0.2s ease;
+  font-size: 15px;
+  font-weight: 600;
+  color: #0f172a;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow:
+    0 2px 8px rgba(15, 23, 42, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  position: relative;
+  overflow: hidden;
+
+  /* 호버 시 배경 효과 */
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    z-index: 0;
+  }
 
   &:hover {
-    border-color: #3b82f6;
+    border-color: rgba(59, 130, 246, 0.4);
+    transform: translateY(-2px);
+    box-shadow:
+      0 4px 16px rgba(59, 130, 246, 0.12),
+      inset 0 1px 0 rgba(255, 255, 255, 1);
+
+    &::before {
+      opacity: 1;
+    }
   }
 
   &:focus {
     outline: none;
     border-color: #3b82f6;
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+    box-shadow:
+      0 0 0 4px rgba(59, 130, 246, 0.15),
+      0 2px 8px rgba(15, 23, 42, 0.06),
+      inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  }
+
+  &:active {
+    transform: translateY(0);
   }
 
   &:disabled {
-    background-color: #f9fafb;
+    background: linear-gradient(135deg, #f9fafb 0%, #f1f5f9 100%);
     color: #9ca3af;
     cursor: not-allowed;
+    border-color: #e5e7eb;
+
+    &:hover {
+      transform: none;
+      box-shadow: none;
+
+      &::before {
+        opacity: 0;
+      }
+    }
+  }
+
+  & > * {
+    position: relative;
+    z-index: 1;
   }
 `;
 
@@ -52,38 +121,37 @@ export const DropDownHeader = styled.button`
  * 헤더 내 라벨 텍스트
  */
 export const HeaderLabel = styled.span`
-  font-weight: 500;
+  font-weight: 600;
   color: inherit;
   flex: 1;
   text-align: left;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  margin-right: 8px;
-
-  /* TODO: 다중 선택 시 고급 텍스트 처리를 위한 추가 스타일
-   * JavaScript와 조합하여 다음과 같은 기능 구현 예정:
-   * - 실제 텍스트 길이 측정
-   * - 영역을 초과하는 경우 마지막 완전한 단어 뒤에 '...' 추가
-   * - 예: "06:00-09:00, 09:00-12:00" -> "06:00-09:00, 09:00-..."
-   */
+  margin-right: 12px;
+  letter-spacing: -0.01em;
 `;
-
-/* TODO: 다중 선택용 특수 헤더 라벨 (추후 구현)
-export const MultiSelectHeaderLabel = styled(HeaderLabel)`
-  // JavaScript ResizeObserver와 함께 사용할 고급 텍스트 처리
-  // 실시간으로 텍스트 길이를 측정하여 적절한 위치에서 자르기
-`;
-*/
 
 /**
  * 토글 아이콘
  */
 export const ToggleIcon = styled.span<{ isOpen: boolean }>`
-  transition: transform 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+  background: ${({ isOpen }) =>
+    isOpen
+      ? 'linear-gradient(135deg, #DBEAFE 0%, #BFDBFE 100%)'
+      : 'rgba(148, 163, 184, 0.1)'};
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   transform: ${({ isOpen }) => (isOpen ? 'rotate(180deg)' : 'rotate(0deg)')};
-  font-size: 12px;
-  color: #6b7280;
+  font-size: 14px;
+  color: ${({ isOpen }) => (isOpen ? '#1E40AF' : '#64748B')};
+  box-shadow: ${({ isOpen }) =>
+    isOpen ? '0 2px 8px rgba(59, 130, 246, 0.15)' : 'none'};
 `;
 
 /**
@@ -91,31 +159,42 @@ export const ToggleIcon = styled.span<{ isOpen: boolean }>`
  */
 export const DropDownList = styled.div<{ isOpen: boolean }>`
   position: absolute;
-  top: 100%;
+  top: calc(100% + 8px);
   left: 0;
   right: 0;
   z-index: 1000;
-  background-color: white;
-  border: 1px solid #d1d5db;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  max-height: 240px;
+  background: rgba(255, 255, 255, 0.98);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  border-radius: 16px;
+  box-shadow:
+    0 8px 32px rgba(15, 23, 42, 0.12),
+    0 4px 16px rgba(59, 130, 246, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  max-height: 280px;
   overflow-y: auto;
-  margin-top: 4px;
 
   ${({ isOpen }) => css`
     display: ${isOpen ? 'block' : 'none'};
-    animation: ${isOpen ? 'slideDown 0.2s ease' : 'none'};
+    animation: ${isOpen ? slideDown : 'none'} 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   `}
 
-  @keyframes slideDown {
-    from {
-      opacity: 0;
-      transform: translateY(-8px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
+  /* 스크롤바 스타일링 */
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+    margin: 8px 0;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(148, 163, 184, 0.3);
+    border-radius: 4px;
+
+    &:hover {
+      background: rgba(148, 163, 184, 0.5);
     }
   }
 `;
@@ -129,33 +208,56 @@ export const DropDownOption = styled.div<{
 }>`
   display: flex;
   align-items: center;
-  padding: 8px 16px;
+  padding: 12px 16px;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
-  transition: background-color 0.2s ease;
-  border-bottom: 1px solid #f3f4f6;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  border-bottom: 1px solid rgba(241, 245, 249, 0.8);
+  position: relative;
+
+  &:first-of-type {
+    border-radius: 16px 16px 0 0;
+  }
 
   &:last-child {
     border-bottom: none;
+    border-radius: 0 0 16px 16px;
   }
 
   ${({ isSelected, disabled }) => {
     if (disabled) {
       return css`
-        background-color: #f9fafb;
+        background-color: rgba(249, 250, 251, 0.5);
         color: #9ca3af;
       `;
     }
 
     if (isSelected) {
       return css`
-        background-color: rgba(59, 130, 246, 0.1);
-        color: #3b82f6;
+        background: linear-gradient(
+          135deg,
+          rgba(59, 130, 246, 0.08) 0%,
+          rgba(147, 197, 253, 0.08) 100%
+        );
+        color: #1e40af;
+        font-weight: 600;
+
+        &::before {
+          content: '';
+          position: absolute;
+          left: 0;
+          top: 0;
+          bottom: 0;
+          width: 3px;
+          background: linear-gradient(180deg, #3b82f6 0%, #8b5cf6 100%);
+          border-radius: 0 3px 3px 0;
+        }
       `;
     }
 
     return css`
       &:hover {
-        background-color: #f9fafb;
+        background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+        transform: translateX(4px);
       }
     `;
   }}
@@ -171,13 +273,17 @@ export const SelectionIndicator = styled.span<{
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 18px;
-  height: 18px;
-  margin-right: 8px;
-  border: 2px solid ${({ isSelected }) => (isSelected ? '#3b82f6' : '#d1d5db')};
-  background-color: ${({ isSelected }) =>
-    isSelected ? '#3b82f6' : 'transparent'};
-  transition: all 0.2s ease;
+  width: 22px;
+  height: 22px;
+  margin-right: 12px;
+  border: 2px solid ${({ isSelected }) => (isSelected ? '#3B82F6' : '#CBD5E1')};
+  background: ${({ isSelected }) =>
+    isSelected ? 'linear-gradient(135deg, #3B82F6 0%, #2563EB 100%)' : 'white'};
+  transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  box-shadow: ${({ isSelected }) =>
+    isSelected
+      ? '0 4px 12px rgba(59, 130, 246, 0.3)'
+      : '0 2px 4px rgba(15, 23, 42, 0.06)'};
 
   ${({ selectionMode }) =>
     selectionMode === 'single'
@@ -185,15 +291,20 @@ export const SelectionIndicator = styled.span<{
           border-radius: 50%;
         `
       : css`
-          border-radius: 3px;
+          border-radius: 6px;
         `}
 
-  // TODO : 해당 부분 '✓'는 추후 아이콘으로 수정해야할 듯?
+  ${({ isSelected }) =>
+    isSelected &&
+    css`
+      transform: scale(1.1);
+    `}
+
   &::after {
     content: ${({ isSelected }) => (isSelected ? "'✓'" : "''")};
     color: white;
-    font-size: 12px;
-    font-weight: bold;
+    font-size: 14px;
+    font-weight: 900;
   }
 `;
 
@@ -202,6 +313,7 @@ export const SelectionIndicator = styled.span<{
  */
 export const OptionLabel = styled.span`
   flex: 1;
-  font-size: 16px;
-  line-height: 1.4;
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: -0.01em;
 `;

--- a/src/components/titleBar/loginTitleBar/loginTitleBar.styled.ts
+++ b/src/components/titleBar/loginTitleBar/loginTitleBar.styled.ts
@@ -1,16 +1,86 @@
+import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
+import { CgProfile } from 'react-icons/cg';
 
 import TitleBar from '@/components/titleBar';
-import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
 import { typography } from '@/theme/typography';
 
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const float = keyframes`
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+`;
+
 export const Wrapper = styled(TitleBar)`
-  background-color: ${colors.background.default};
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(20px);
+  height: 68px;
   padding: 0 ${spacing.spacing4};
+  border-bottom: 1px solid rgba(226, 232, 240, 0.6);
+  box-shadow:
+    0 2px 12px rgba(15, 23, 42, 0.04),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.8);
+  animation: ${fadeIn} 0.5s ease-out;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+
+  &:hover {
+    box-shadow:
+      0 4px 20px rgba(15, 23, 42, 0.08),
+      inset 0 -1px 0 rgba(255, 255, 255, 0.8);
+  }
 
   & > div:nth-of-type(2) {
     ${typography.title1Bold};
-    color: ${colors.text.default};
+    font-size: 24px;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    background: linear-gradient(135deg, #1e40af 0%, #3b82f6 50%, #8b5cf6 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    text-shadow: 0 2px 8px rgba(59, 130, 246, 0.15);
+    animation: ${float} 3s ease-in-out infinite;
+  }
+`;
+
+export const ProfileIcon = styled(CgProfile)`
+  width: 44px;
+  height: 44px;
+  color: #3b82f6;
+  padding: 8px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(59, 130, 246, 0.15);
+
+  &:hover {
+    transform: translateY(-2px) scale(1.05);
+    box-shadow: 0 4px 16px rgba(59, 130, 246, 0.25);
+    background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
+    color: #2563eb;
+  }
+
+  &:active {
+    transform: translateY(0) scale(1);
+    box-shadow: 0 2px 8px rgba(59, 130, 246, 0.2);
   }
 `;

--- a/src/components/titleBar/loginTitleBar/loginTitleBar.tsx
+++ b/src/components/titleBar/loginTitleBar/loginTitleBar.tsx
@@ -1,7 +1,7 @@
 import * as S from './loginTitleBar.styled';
 
 const LoginTitleBar = () => {
-  return <S.Wrapper title="로그인" />;
+  return <S.Wrapper title="로그인" rightSlot={<S.ProfileIcon />} />;
 };
 
 export default LoginTitleBar;

--- a/src/pages/Auth/LoginPage.styled.ts
+++ b/src/pages/Auth/LoginPage.styled.ts
@@ -1,72 +1,195 @@
+import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
 import { typography } from '@/theme/typography';
 
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const shimmer = keyframes`
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+`;
+
+const float = keyframes`
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+`;
+
 export const Section = styled.main`
   display: grid;
   gap: ${spacing.spacing5};
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+  position: relative;
+
+  /* 배경 패턴 효과 */
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 500px;
+    background: radial-gradient(
+      circle at 50% 0%,
+      rgba(59, 130, 246, 0.08) 0%,
+      transparent 70%
+    );
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  /* 하단 그라디언트 */
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 300px;
+    background: linear-gradient(
+      180deg,
+      transparent 0%,
+      rgba(148, 163, 184, 0.05) 100%
+    );
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  & > * {
+    position: relative;
+    z-index: 1;
+  }
 `;
 
 export const TitleBarWrapper = styled.div`
   margin: -${spacing.spacing6} -${spacing.spacing5} 0;
   padding-bottom: ${spacing.spacing4};
+  animation: ${fadeIn} 0.5s ease-out;
 `;
 
 export const Header = styled.header`
   display: grid;
-  gap: ${spacing.spacing4};
+  gap: ${spacing.spacing5};
+  padding: ${spacing.spacing8} ${spacing.spacing5};
+  max-width: 480px;
+  margin: 0 auto;
+  width: 100%;
+  animation: ${fadeIn} 0.6s ease-out 0.1s backwards;
 `;
 
 export const HeaderContent = styled.div`
   display: grid;
-  gap: ${spacing.spacing2};
+  gap: ${spacing.spacing3};
+  text-align: center;
+  position: relative;
+
+  &::before {
+    content: '🏀';
+    font-size: 64px;
+    display: block;
+    margin: 0 auto ${spacing.spacing3};
+    animation: ${float} 3s ease-in-out infinite;
+    filter: drop-shadow(0 4px 12px rgba(59, 130, 246, 0.3));
+  }
 `;
 
 export const Title = styled.h1`
   margin: 0;
-  text-align: center;
   ${typography.title1Bold};
-  color: ${colors.text.default};
+  font-size: 32px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  background: linear-gradient(135deg, #0f172a 0%, #1e40af 50%, #3b82f6 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  text-align: center;
 `;
 
 export const Description = styled.p`
   margin: 0;
   ${typography.body1Regular};
+  font-size: 16px;
+  font-weight: 500;
   color: ${colors.text.sub};
   text-align: center;
+  line-height: 1.6;
+  opacity: 0.9;
 `;
 
 export const ExpiredNotice = styled.div`
   display: flex;
   align-items: center;
   gap: ${spacing.spacing2};
-  padding: ${spacing.spacing2} ${spacing.spacing3};
-  border-radius: 14px;
-  background-color: ${colors.status.criticalBackground};
-  color: ${colors.status.critical};
+  padding: ${spacing.spacing3} ${spacing.spacing4};
+  border-radius: 16px;
+  background: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%);
+  color: #991b1b;
   ${typography.body2Bold};
+  font-weight: 600;
+  box-shadow:
+    0 4px 16px rgba(220, 38, 38, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  border: 1px solid rgba(220, 38, 38, 0.2);
+  animation: ${fadeIn} 0.5s ease-out;
+
+  &::before {
+    content: '⚠️';
+    font-size: 20px;
+  }
 `;
 
 export const ButtonStack = styled.div`
   display: grid;
   gap: ${spacing.spacing3};
+  max-width: 480px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 0 ${spacing.spacing5};
+  animation: ${fadeIn} 0.6s ease-out 0.2s backwards;
 `;
 
 export const Divider = styled.div`
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  gap: ${spacing.spacing2};
+  gap: ${spacing.spacing3};
   color: ${colors.text.placeholder};
   ${typography.label1Regular};
+  font-size: 13px;
+  font-weight: 600;
+  margin: ${spacing.spacing2} 0;
 
   &::before,
   &::after {
     content: '';
-    height: 1px;
-    background-color: ${colors.border.disabled};
+    height: 2px;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      rgba(226, 232, 240, 0.8) 50%,
+      transparent 100%
+    );
   }
 `;
 
@@ -77,7 +200,12 @@ export const DummyButtonWrapper = styled.div`
 
 export const StatusRegion = styled.div`
   display: grid;
-  gap: ${spacing.spacing2};
+  gap: ${spacing.spacing3};
+  max-width: 480px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 0 ${spacing.spacing5};
+  animation: ${fadeIn} 0.6s ease-out 0.3s backwards;
 `;
 
 const statusBase = `
@@ -85,66 +213,156 @@ const statusBase = `
   align-items: flex-start;
   justify-content: space-between;
   gap: ${spacing.spacing3};
-  padding: ${spacing.spacing3};
-  border-radius: 16px;
-  transition: background-color 160ms ease;
+  padding: ${spacing.spacing4};
+  border-radius: 20px;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 
+    0 4px 16px rgba(15, 23, 42, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  border: 1px solid;
+  position: relative;
+  overflow: hidden;
+  
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    opacity: 0.8;
+  }
 `;
 
 export const StatusMessage = styled.div`
   ${statusBase};
-  background-color: ${colors.status.infoBackground};
-  color: ${colors.status.info};
+  background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+  color: #1e40af;
+  border-color: rgba(59, 130, 246, 0.2);
+
+  &::before {
+    background: linear-gradient(90deg, #3b82f6 0%, #8b5cf6 100%);
+  }
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow:
+      0 8px 24px rgba(59, 130, 246, 0.15),
+      inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  }
 `;
 
 export const ErrorMessage = styled.div`
   ${statusBase};
-  background-color: ${colors.status.criticalBackground};
-  color: ${colors.status.critical};
+  background: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%);
+  color: #991b1b;
+  border-color: rgba(220, 38, 38, 0.2);
+
+  &::before {
+    background: linear-gradient(90deg, #ef4444 0%, #dc2626 100%);
+  }
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow:
+      0 8px 24px rgba(220, 38, 38, 0.15),
+      inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  }
 `;
 
 export const StatusContent = styled.div`
   display: grid;
   gap: ${spacing.spacing1};
+  flex: 1;
 `;
 
 export const StatusTitle = styled.p`
   margin: 0;
   ${typography.body1Bold};
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
 `;
 
 export const StatusDescription = styled.p`
   margin: 0;
   ${typography.body2Regular};
+  font-size: 14px;
   color: inherit;
+  opacity: 0.9;
+  line-height: 1.5;
 `;
 
 export const RetryButton = styled.button`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: ${spacing.spacing2} ${spacing.spacing3};
-  border-radius: 12px;
+  gap: ${spacing.spacing1};
+  padding: ${spacing.spacing2} ${spacing.spacing4};
+  border-radius: 14px;
   border: none;
-  background-color: ${colors.background.default};
+  background: linear-gradient(135deg, #ffffff 0%, #fef2f2 100%);
   ${typography.label1Bold};
-  color: ${colors.status.critical};
+  font-size: 14px;
+  font-weight: 700;
+  color: #dc2626;
   cursor: pointer;
-  transition:
-    transform 120ms ease,
-    box-shadow 180ms ease;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow:
+    0 2px 8px rgba(220, 38, 38, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(220, 38, 38, 0.2);
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgba(255, 255, 255, 0.3),
+      transparent
+    );
+    background-size: 200% 100%;
+    animation: ${shimmer} 2s ease-in-out infinite;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
 
   &:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 8px 18px rgba(250, 52, 44, 0.18);
+    transform: translateY(-2px);
+    box-shadow:
+      0 4px 16px rgba(220, 38, 38, 0.25),
+      inset 0 1px 0 rgba(255, 255, 255, 1);
+    background: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%);
+
+    &::before {
+      opacity: 1;
+    }
   }
 
   &:active {
     transform: translateY(0);
-    box-shadow: 0 2px 8px rgba(250, 52, 44, 0.2);
+    box-shadow:
+      0 2px 8px rgba(220, 38, 38, 0.2),
+      inset 0 1px 0 rgba(255, 255, 255, 0.8);
   }
 
   &:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 3px rgba(250, 52, 44, 0.35);
+    box-shadow:
+      0 0 0 4px rgba(220, 38, 38, 0.2),
+      0 2px 8px rgba(220, 38, 38, 0.15);
+  }
+
+  &::after {
+    content: '↻';
+    font-size: 16px;
+    margin-left: 4px;
   }
 `;

--- a/src/tests/component/titleBar/loginTitleBar.test.tsx
+++ b/src/tests/component/titleBar/loginTitleBar.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 
 import LoginTitleBar from '@/components/titleBar/loginTitleBar';
-import { colors } from '@/theme/color';
 import { typography } from '@/theme/typography';
 
 describe('LoginTitleBar 컴포넌트', () => {
@@ -11,19 +10,18 @@ describe('LoginTitleBar 컴포넌트', () => {
     expect(screen.getByText('로그인')).toBeInTheDocument();
   });
 
-  it('좌우 슬롯이 비어 있다', () => {
+  it('좌측 슬롯은 비어 있고 우측 슬롯에는 프로필 아이콘이 있다', () => {
     render(<LoginTitleBar />);
     const header = screen.getByRole('banner');
     expect(header.firstChild).toBeEmptyDOMElement();
-    expect(header.lastChild).toBeEmptyDOMElement();
+    expect(header.lastChild).not.toBeEmptyDOMElement();
   });
 
   it('스타일이 적용된다', () => {
     render(<LoginTitleBar />);
     const header = screen.getByRole('banner');
-    expect(header).toHaveStyle(
-      `background-color: ${colors.background.default}`,
-    );
+    expect(header).toHaveStyle('background: rgba(255, 255, 255, 0.95)');
+    expect(header).toHaveStyle('position: sticky');
 
     const title = screen.getByText('로그인');
     expect(title).toHaveStyle(


### PR DESCRIPTION
## Summary
- redesign the login page section with gradient background, animated headers, and richer status styling
- enhance the dropdown component with animated transitions and refined hover/selection treatments
- update the login title bar to surface a profile icon slot and align its unit test with the new presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690d0911144883328ca1e6dc6e332057