### PR TITLE
Enhance match detail page visuals

### DIFF
--- a/src/components/titleBar/originTitleBar/originTitleBar.styled.ts
+++ b/src/components/titleBar/originTitleBar/originTitleBar.styled.ts
@@ -1,16 +1,70 @@
+import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { MdArrowBack } from 'react-icons/md';
 
 import TitleBar from '@/components/titleBar';
-import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
 
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
 export const Wrapper = styled(TitleBar)`
-  background-color: #e1eefc;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(20px);
+  height: 64px;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.6);
+  box-shadow:
+    0 2px 12px rgba(15, 23, 42, 0.04),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.8);
+  animation: ${fadeIn} 0.5s ease-out;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+
+  &:hover {
+    box-shadow:
+      0 4px 20px rgba(15, 23, 42, 0.08),
+      inset 0 -1px 0 rgba(255, 255, 255, 0.8);
+  }
+
+  /* 타이틀 텍스트 스타일링 */
+  & > div:nth-of-type(2) {
+    font-size: 18px;
+    font-weight: 700;
+    color: #0f172a;
+    letter-spacing: -0.02em;
+  }
 `;
 
 export const BackIcon = styled(MdArrowBack)`
   width: ${spacing.spacing5};
   height: ${spacing.spacing5};
-  color: ${colors.text.default};
+  color: #3b82f6;
+  padding: 8px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+  box-shadow: 0 2px 8px rgba(59, 130, 246, 0.15);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  cursor: pointer;
+
+  &:hover {
+    transform: translateX(-2px) scale(1.05);
+    box-shadow: 0 4px 16px rgba(59, 130, 246, 0.25);
+    background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
+    color: #2563eb;
+  }
+
+  &:active {
+    transform: translateX(0) scale(1);
+    box-shadow: 0 2px 8px rgba(59, 130, 246, 0.2);
+  }
 `;

--- a/src/pages/MatchDetail/MatchDetailPage.styled.ts
+++ b/src/pages/MatchDetail/MatchDetailPage.styled.ts
@@ -1,72 +1,405 @@
+import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 
-import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const shimmer = keyframes`
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+`;
+
+const scaleIn = keyframes`
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+`;
+
+const pulse = keyframes`
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+`;
 
 export const PageContainer = styled.div`
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  background-color: ${colors.gray[0]};
+  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+  position: relative;
+
+  /* 배경 패턴 효과 */
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 500px;
+    background: radial-gradient(
+      circle at 50% 0%,
+      rgba(59, 130, 246, 0.08) 0%,
+      transparent 70%
+    );
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  & > * {
+    position: relative;
+    z-index: 1;
+  }
 `;
 
 export const ImageContainer = styled.div`
   width: 100%;
-  max-height: 400px;
+  max-height: 480px;
   overflow: hidden;
-  background-color: ${colors.gray[100]};
+  background: linear-gradient(135deg, #e2e8f0 0%, #cbd5e1 100%);
+  position: relative;
+  animation: ${fadeIn} 0.6s ease-out;
+
+  /* 이미지 로딩 shimmer 효과 */
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      rgba(255, 255, 255, 0.3) 50%,
+      transparent 100%
+    );
+    background-size: 200% 100%;
+    animation: ${shimmer} 2s ease-in-out infinite;
+    z-index: 1;
+    pointer-events: none;
+  }
+
+  /* 하단 그라디언트 오버레이 */
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 120px;
+    background: linear-gradient(
+      180deg,
+      transparent 0%,
+      rgba(15, 23, 42, 0.6) 100%
+    );
+    z-index: 2;
+    pointer-events: none;
+  }
 `;
 
 export const MatchImage = styled.img`
   width: 100%;
   height: auto;
-  max-height: 400px;
+  max-height: 480px;
   object-fit: cover;
   object-position: center;
   display: block;
+  position: relative;
+  z-index: 0;
+  transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
 
-  /* 세로가 더 긴 이미지인 경우 정중앙 기준 1:1로 크롭 */
+  /* 세로가 더 긴 이미지인 경우 정중앙 기준으로 크롭 */
   aspect-ratio: auto;
 
-  @supports (aspect-ratio: 1 / 1) {
-    /* 이미지 높이가 너비보다 큰 경우 1:1 비율로 제한 */
-    max-height: min(400px, 100vw);
+  @supports (aspect-ratio: 16 / 9) {
+    max-height: min(480px, calc(100vw * 9 / 16));
+  }
+
+  ${ImageContainer}:hover & {
+    transform: scale(1.05);
   }
 `;
 
 export const ContentContainer = styled.div`
   flex: 1;
-  padding: ${spacing.spacing4};
+  padding: ${spacing.spacing5};
   overflow-y: auto;
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+  animation: ${fadeIn} 0.6s ease-out 0.2s backwards;
+
+  /* 스크롤바 스타일링 */
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(148, 163, 184, 0.3);
+    border-radius: 4px;
+
+    &:hover {
+      background: rgba(148, 163, 184, 0.5);
+    }
+  }
 `;
 
 export const ButtonContainer = styled.div`
-  padding: ${spacing.spacing4};
-  padding-top: ${spacing.spacing2};
-  background-color: ${colors.gray[0]};
+  padding: ${spacing.spacing5};
+  padding-top: ${spacing.spacing3};
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(20px);
+  border-top: 1px solid rgba(226, 232, 240, 0.6);
+  box-shadow:
+    0 -4px 20px rgba(15, 23, 42, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  position: sticky;
+  bottom: 0;
+  z-index: 100;
+  animation: ${scaleIn} 0.5s ease-out;
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
 
   button {
     width: 100%;
-    height: 56px;
-    font-size: 18px;
-    font-weight: 600;
+    height: 60px;
+    font-size: 17px;
+    font-weight: 700;
+    border-radius: 16px;
+    border: none;
+    background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+    color: white;
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow:
+      0 4px 20px rgba(59, 130, 246, 0.3),
+      inset 0 1px 0 rgba(255, 255, 255, 0.2);
+    position: relative;
+    overflow: hidden;
+    letter-spacing: -0.01em;
+
+    /* Shimmer 효과 */
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: linear-gradient(
+        90deg,
+        transparent,
+        rgba(255, 255, 255, 0.3),
+        transparent
+      );
+      background-size: 200% 100%;
+      animation: ${shimmer} 2s ease-in-out infinite;
+    }
+
+    &:hover {
+      transform: translateY(-2px);
+      box-shadow:
+        0 8px 30px rgba(59, 130, 246, 0.4),
+        inset 0 1px 0 rgba(255, 255, 255, 0.3);
+    }
+
+    &:active {
+      transform: translateY(0);
+      box-shadow:
+        0 2px 12px rgba(37, 99, 235, 0.4),
+        inset 0 1px 0 rgba(255, 255, 255, 0.2);
+    }
+
+    &:disabled {
+      background: linear-gradient(135deg, #e2e8f0 0%, #cbd5e1 100%);
+      color: #94a3b8;
+      cursor: not-allowed;
+      transform: none;
+      box-shadow: none;
+
+      &::before {
+        display: none;
+      }
+    }
   }
 `;
 
 export const LoadingContainer = styled.div`
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: ${spacing.spacing4};
   flex: 1;
-  font-size: 18px;
-  color: ${colors.gray[600]};
+  padding: ${spacing.spacing8};
+
+  &::before {
+    content: '⏳';
+    font-size: 64px;
+    animation: ${pulse} 1.5s ease-in-out infinite;
+    filter: drop-shadow(0 4px 12px rgba(59, 130, 246, 0.3));
+  }
+
+  &::after {
+    content: '매치 정보를 불러오는 중...';
+    font-size: 16px;
+    font-weight: 600;
+    color: #64748b;
+    text-align: center;
+  }
 `;
 
 export const ErrorContainer = styled.div`
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: ${spacing.spacing4};
   flex: 1;
+  padding: ${spacing.spacing8};
+
+  &::before {
+    content: '😢';
+    font-size: 64px;
+    animation: ${pulse} 2s ease-in-out infinite;
+    filter: drop-shadow(0 4px 12px rgba(239, 68, 68, 0.3));
+  }
+
+  &::after {
+    content: '매치 정보를 불러올 수 없습니다';
+    font-size: 16px;
+    font-weight: 600;
+    color: #dc2626;
+    text-align: center;
+  }
+`;
+
+/**
+ * 추가 스타일: 매치 정보 섹션들을 위한 카드 스타일
+ */
+export const InfoCard = styled.div`
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(10px);
+  border-radius: 20px;
+  padding: ${spacing.spacing4};
+  margin-bottom: ${spacing.spacing4};
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  box-shadow:
+    0 2px 12px rgba(15, 23, 42, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow:
+      0 8px 24px rgba(15, 23, 42, 0.1),
+      inset 0 1px 0 rgba(255, 255, 255, 1);
+  }
+`;
+
+export const InfoTitle = styled.h3`
+  margin: 0 0 ${spacing.spacing3} 0;
   font-size: 18px;
-  color: ${colors.red[600]};
+  font-weight: 700;
+  color: #0f172a;
+  letter-spacing: -0.02em;
+  display: flex;
+  align-items: center;
+  gap: ${spacing.spacing2};
+
+  &::before {
+    content: '';
+    width: 4px;
+    height: 20px;
+    background: linear-gradient(180deg, #3b82f6 0%, #8b5cf6 100%);
+    border-radius: 2px;
+  }
+`;
+
+export const InfoRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: ${spacing.spacing2} 0;
+  border-bottom: 1px solid rgba(241, 245, 249, 0.8);
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+export const InfoLabel = styled.span`
+  font-size: 14px;
+  font-weight: 600;
+  color: #64748b;
+`;
+
+export const InfoValue = styled.span`
+  font-size: 15px;
+  font-weight: 700;
+  color: #0f172a;
+  letter-spacing: -0.01em;
+`;
+
+/**
+ * 상태 배지
+ */
+export const StatusBadge = styled.span<{
+  status?: 'recruiting' | 'full' | 'closed';
+}>`
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 14px;
+  border-radius: 12px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+
+  ${({ status = 'recruiting' }) => {
+    switch (status) {
+      case 'full':
+        return `
+          background: linear-gradient(135deg, #FEF3C7 0%, #FDE68A 100%);
+          color: #78350F;
+        `;
+      case 'closed':
+        return `
+          background: linear-gradient(135deg, #F3F4F6 0%, #E5E7EB 100%);
+          color: #4B5563;
+        `;
+      default:
+        return `
+          background: linear-gradient(135deg, #D1FAE5 0%, #A7F3D0 100%);
+          color: #065F46;
+        `;
+    }
+  }}
 `;

--- a/src/tests/component/titleBar/originTitleBar.test.tsx
+++ b/src/tests/component/titleBar/originTitleBar.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 
 import OriginTitleBar from '@/components/titleBar/originTitleBar';
-import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
 import { typography } from '@/theme/typography';
 
@@ -24,10 +23,11 @@ describe('OriginTitleBar 컴포넌트', () => {
 
     const backButton = screen.getByLabelText('뒤로 가기');
     expect(backButton).toHaveStyle(`width: ${spacing.spacing10}`);
-    expect(backButton).toHaveStyle(`color: ${colors.text.default}`);
-
     const icon = backButton.firstChild as HTMLElement;
-    expect(icon).toHaveStyle(`color: ${colors.text.default}`);
+    expect(icon).toHaveStyle('color: rgb(59, 130, 246)');
+    expect(icon).toHaveStyle(
+      'background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%)',
+    );
 
     const title = screen.getByText('기본');
     expect(title).toHaveStyle(


### PR DESCRIPTION
## Summary
- refresh the match detail layout with animated gradients, card styles, and refined containers
- restyle the origin title bar with blur, gradients, and hover feedback to match the new aesthetic
- align origin title bar tests with the updated icon styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690d0b7f7b748332b81fd93bddfa88f4